### PR TITLE
docs: fix README broken hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For common usage patterns and examples, see our [Cookbook](docs/cookbook/index.e
 
 Comprehensive documentation is available [here](https://folhasp.github.io/mosaico). Documentation includes:
 
-- [Getting Started](https://folhasp.github.io/mosaico/getting-started): Installation, setup, and basic usage
+- [Getting Started](https://folhasp.github.io/mosaico): Installation, setup, and basic usage
 - [Concepts](https://folhasp.github.io/mosaico/concepts): Overview of key concepts and terminology
 - [Cookbook](https://folhasp.github.io/mosaico/cookbook): Examples and tutorials for common tasks
 - [API Reference](https://folhasp.github.io/mosaico/api-reference): Detailed reference for all classes and functions

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ For common usage patterns and examples, see our [Cookbook](docs/cookbook/index.e
 
 Comprehensive documentation is available [here](https://folhasp.github.io/mosaico). Documentation includes:
 
-- [Getting Started](https://folhasp.github.io/mosaico/getting_started.html): Installation, setup, and basic usage
-- [Concepts](https://folhasp.github.io/mosaico/concepts.html): Overview of key concepts and terminology
-- [Cookbook](https://folhasp.github.io/mosaico/cookbook.html): Examples and tutorials for common tasks
-- [API Reference](https://folhasp.github.io/mosaico/api.html): Detailed reference for all classes and functions
-- [Development](https://folhasp.github.io/mosaico/development.html): Information for contributors and developers
-- [Roadmap](https://folhasp.github.io/mosaico/roadmap.html): Future plans and features
+- [Getting Started](https://folhasp.github.io/mosaico/getting-started): Installation, setup, and basic usage
+- [Concepts](https://folhasp.github.io/mosaico/concepts): Overview of key concepts and terminology
+- [Cookbook](https://folhasp.github.io/mosaico/cookbook): Examples and tutorials for common tasks
+- [API Reference](https://folhasp.github.io/mosaico/api-reference): Detailed reference for all classes and functions
+- [Development](https://folhasp.github.io/mosaico/development): Information for contributors and developers
+- [Roadmap](https://folhasp.github.io/mosaico/roadmap): Future plans and features
 
 ## References
 


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to correct and simplify the URLs in the documentation links.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R68): Updated URLs for the "Getting Started", "Concepts", "Cookbook", "API Reference", "Development", and "Roadmap" sections to remove `.html` extensions and ensure consistency in the documentation links.

Closes #1 