### PR TITLE
feat: add workflow for package publishing and update version to 0.1.0rc1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish Package
+
+on:
+  release:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  publish:
+    if: "!cancelled()"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+      - name: Build the package
+        run: uv build
+      - name: Publish the package
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: uv publish --token $UV_PUBLISH_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mosaico"
-version = "0.1.0-rc0"
+version = "0.1.0rc1"
 description = "Open-source video generation framework"
 authors = [
     { name = "Leonardo Diegues", email = "leonardo.diegues@grupofolha.com.br" },
@@ -8,6 +8,20 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: GNU General Public License (GPL)",
+    "Operating System :: OS Independent",
+    "Topic :: Multimedia",
+    "Topic :: Multimedia :: Video :: Non-Linear Editor",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+    "Topic :: Multimedia :: Sound/Audio :: Sound Synthesis",
+    "Topic :: Text Processing :: Fonts",
+
+]
 dependencies = [
     "pydantic",
     "pyyaml",


### PR DESCRIPTION
This pull request includes changes to automate the publishing process for the package and updates to the package metadata in `pyproject.toml`. The most important changes are summarized below:

### CI/CD Automation:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R31): Added a new GitHub Actions workflow to publish the package when a release is created. This workflow sets up the necessary environment, builds the package, and publishes it using a secret token.

### Package Metadata:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R24): Updated the package version from `0.1.0-rc0` to `0.1.0rc1` and added classifiers for better categorization and compatibility information.