### PR TITLE
feat: load remote media with `fsspec`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydantic-extra-types>=2.9.0",
     "pycountry>=24.6.1",
     "tinytag>=1.10.1",
+    "fsspec>=2024.10.0",
 ]
 
 [project.scripts]

--- a/src/mosaico/clip_makers/audio.py
+++ b/src/mosaico/clip_makers/audio.py
@@ -42,7 +42,10 @@ class AudioClipMaker(BaseClipMaker[AudioAsset]):
         """
         clip_duration = self.duration if self.duration is not None else asset.duration
 
-        with asset.to_bytes_io() as audio_buf, NamedTemporaryFile(mode="wb", suffix=".mp3") as temp_file:
+        with (
+            asset.to_bytes_io(storage_options=self.storage_options) as audio_buf,
+            NamedTemporaryFile(mode="wb", suffix=".mp3") as temp_file,
+        ):
             audio = AudioSegment.from_file(
                 file=audio_buf,
                 sample_width=asset.sample_width,

--- a/src/mosaico/clip_makers/base.py
+++ b/src/mosaico/clip_makers/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from moviepy.Clip import Clip
 from pydantic import BaseModel
@@ -29,6 +29,9 @@ class BaseClipMaker(BaseModel, Generic[T], ABC):
     effects: list[Effect] = Field(default_factory=list)
     """List of effects to apply to the clip."""
 
+    storage_options: dict[str, Any] = Field(default_factory=dict)
+    """Storage options for the media."""
+
     model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
     @abstractmethod
@@ -40,7 +43,7 @@ class BaseClipMaker(BaseModel, Generic[T], ABC):
         """
         Make a clip from the given clip, duration and video resolution.
 
-        :clip: The clip to make the clip from.
+        :asset: The asset to make the clip from.
         :duration: The duration of the clip in seconds.
         :video_resolution: The resolution of the video.
         :return: The clip.

--- a/src/mosaico/clip_makers/factory.py
+++ b/src/mosaico/clip_makers/factory.py
@@ -66,6 +66,7 @@ def make_clip(
     duration: float | None = None,
     video_resolution: FrameSize | None = None,
     effects: Sequence[Effect] | None = None,
+    storage_options: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> Clip:
     """
@@ -82,6 +83,7 @@ def make_clip(
         duration=duration,
         video_resolution=video_resolution,
         effects=list(effects) if effects is not None else [],
+        storage_options=storage_options if storage_options is not None else {},
         **kwargs,
     )
     return clip_maker.make_clip(asset)

--- a/src/mosaico/clip_makers/image.py
+++ b/src/mosaico/clip_makers/image.py
@@ -61,7 +61,7 @@ class ImageClipMaker(BaseClipMaker[ImageAsset]):
         position = asset.params.position
 
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".jpg") as fp:
-            nparr = np.frombuffer(asset.to_bytes(), np.uint8)
+            nparr = np.frombuffer(asset.to_bytes(storage_options=self.storage_options), np.uint8)
             image = cv.imdecode(nparr, cv.IMREAD_COLOR)
 
             # Resize the image if it's not the same resolution as the video

--- a/src/mosaico/clip_makers/text.py
+++ b/src/mosaico/clip_makers/text.py
@@ -92,7 +92,8 @@ class TextClipMaker(BaseClipMaker[BaseTextAsset]):
 
         # Load the font and wrap the text
         font = _load_font(params.font_family, params.font_size)
-        wrapped_text = _wrap_text(asset.to_string(), font, round(max_width * 0.9))
+        text = asset.to_string(storage_options=self.storage_options)
+        wrapped_text = _wrap_text(text, font, round(max_width * 0.9))
         text_size = _get_font_text_size(wrapped_text, font)
 
         shadow_image = None

--- a/tests/assets/test_audio.py
+++ b/tests/assets/test_audio.py
@@ -92,12 +92,6 @@ def test_audio_asset_from_invalid_data():
         AudioAsset.from_data(b"invalid audio data")
 
 
-def test_audio_asset_from_invalid_path():
-    # Test handling non-existent file path
-    with pytest.raises(FileNotFoundError):
-        AudioAsset.from_path("nonexistent_audio.mp3", duration=1.0, sample_rate=44100, sample_width=2, channels=2)
-
-
 def test_audio_asset_params_default_values(sample_audio_data):
     # Test default parameter values
     audio_asset = AudioAsset.from_data(sample_audio_data)

--- a/tests/clip_makers/test_factory.py
+++ b/tests/clip_makers/test_factory.py
@@ -34,15 +34,21 @@ def test_make_clip(mock_get_clip_maker_class) -> None:
     duration = 10.0
     video_resolution = (1920, 1080)
     effects = [Mock(spec=Effect)]
+    storage_options = {}
     kwargs = {"extra_arg": "value"}
 
     result = make_clip(
-        asset=mock_asset, duration=duration, video_resolution=video_resolution, effects=effects, **kwargs
+        asset=mock_asset,
+        duration=duration,
+        video_resolution=video_resolution,
+        effects=effects,
+        storage_options=storage_options,
+        **kwargs,
     )
 
     mock_get_clip_maker_class.assert_called_once_with(mock_asset.type)
     mock_clip_maker_cls.assert_called_once_with(
-        duration=duration, video_resolution=video_resolution, effects=effects, **kwargs
+        duration=duration, video_resolution=video_resolution, effects=effects, storage_options=storage_options, **kwargs
     )
     mock_clip_maker_cls.return_value.make_clip.assert_called_once_with(mock_asset)
     assert result == mock_clip

--- a/uv.lock
+++ b/uv.lock
@@ -1219,10 +1219,11 @@ wheels = [
 
 [[package]]
 name = "mosaico"
-version = "0.1.0rc2"
+version = "0.1.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "findsystemfontsfilename" },
+    { name = "fsspec" },
     { name = "moviepy" },
     { name = "opencv-python" },
     { name = "pycountry" },
@@ -1282,6 +1283,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.1.7" },
     { name = "elevenlabs", marker = "extra == 'elevenlabs'", specifier = ">=1.9.0" },
     { name = "findsystemfontsfilename", specifier = ">=0.3.0" },
+    { name = "fsspec", specifier = ">=2024.10.0" },
     { name = "haystack-ai", marker = "extra == 'haystack'", specifier = ">=2.6.1" },
     { name = "instructor", marker = "extra == 'news'", specifier = ">=1.6.4" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.7" },


### PR DESCRIPTION
This pull request introduces several changes to the `mosaico` project, focusing on adding support for storage options via `fsspec` and improving the handling of media file operations. The key changes include adding storage options to various methods and updating the media handling logic to utilize `fsspec`.

### Storage Options and Media Handling:

* [`src/mosaico/clip_makers/base.py`](diffhunk://#diff-a0c0a4b5f657951c5cf1f9ac5a3b0b57579eb87fe91668e5c157db2d10c9b612R32-R34): Added `storage_options` attribute to `BaseClipMaker` class and updated `make_clip` method to include storage options. [[1]](diffhunk://#diff-a0c0a4b5f657951c5cf1f9ac5a3b0b57579eb87fe91668e5c157db2d10c9b612R32-R34) [[2]](diffhunk://#diff-a0c0a4b5f657951c5cf1f9ac5a3b0b57579eb87fe91668e5c157db2d10c9b612L43-R46)
* [`src/mosaico/clip_makers/factory.py`](diffhunk://#diff-92c2fad6b33a8e72bb750d4d1c96870e922757f0469a1777dd769a5d26c4001fR69): Updated `make_clip` function to accept `storage_options` and pass it to the `BaseClipMaker`. [[1]](diffhunk://#diff-92c2fad6b33a8e72bb750d4d1c96870e922757f0469a1777dd769a5d26c4001fR69) [[2]](diffhunk://#diff-92c2fad6b33a8e72bb750d4d1c96870e922757f0469a1777dd769a5d26c4001fR86)
* `src/mosaico/clip_makers/audio.py`, `src/mosaico/clip_makers/image.py`, `src/mosaico/clip_makers/text.py`: Modified `_make_clip` methods to use storage options when converting assets to bytes or strings. [[1]](diffhunk://#diff-5e2ef2e7c009a56fb257c6fdb4242dab8333925adf45e309e71d98abdcae3876L45-R48) [[2]](diffhunk://#diff-e430093687a0bd8b42662e2bb4b3e2bbd2ac31d61f4ae29680551661876af920L64-R64) [[3]](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46L95-R96)
* [`src/mosaico/media.py`](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL156-R153): Introduced `storage_options` parameter in methods like `to_string`, `to_bytes`, `to_bytes_io`, and added helper functions `_yield_file` and `_load_file` to handle file operations with `fsspec`. [[1]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL156-R153) [[2]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL165-R165) [[3]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL178-R209)

### Dependency and Configuration Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R35): Added `fsspec` as a new dependency to manage file systems.

### Video Rendering Enhancements:

* [`src/mosaico/video/rendering.py`](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L24-R36): Updated `render_video` function and `_render_event_clips` helper function to accept and utilize `storage_options`. [[1]](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L24-R36) [[2]](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L49-R58) [[3]](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L99-R110) [[4]](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L108-R121)

### Testing Adjustments:

* [`tests/clip_makers/test_factory.py`](diffhunk://#diff-ef453cb17505b8f51bb7a4c18e0f6c301a616fd606810913ef3c6574454ba48dR37-R51): Modified `test_make_clip` to include `storage_options` in the test parameters.
* [`tests/assets/test_audio.py`](diffhunk://#diff-fc51998be71bb11cf42d47290d0422a32c1965603f554d06ec17007ae62e8bcbL95-L100): Removed the test for handling non-existent file paths.

Closes #14 