### PR TITLE
hotfix: remove HTTP path validation from Media model

### DIFF
--- a/src/mosaico/media.py
+++ b/src/mosaico/media.py
@@ -66,9 +66,6 @@ class Media(BaseModel):
         if "data" not in values and "path" not in values:
             raise ValueError("Either data or path must be provided")
 
-        if str(values.get("path", "")).startswith("http"):
-            raise ValueError("HTTP paths are not supported")
-
         return values
 
     @classmethod

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -56,11 +56,6 @@ def test_validate_media_without_data_or_path():
         Media()
 
 
-def test_validate_media_with_http_path():
-    with pytest.raises(ValidationError, match="HTTP paths are not supported"):
-        Media(path="http://example.com/image.jpg")
-
-
 def test_from_path(tmp_path):
     file_path = create_temp_file(tmp_path, "test", "test.txt")
     media = Media.from_path(file_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1219,7 +1219,7 @@ wheels = [
 
 [[package]]
 name = "mosaico"
-version = "0.1.0rc3"
+version = "0.1.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "findsystemfontsfilename" },


### PR DESCRIPTION
This pull request includes changes to the `src/mosaico/media.py` and `tests/test_media.py` files to remove the validation for HTTP paths in media paths.

Validation changes:

* [`src/mosaico/media.py`](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL69-L71): Removed the validation that raised a `ValueError` if the media path started with "http".

Test changes:

* [`tests/test_media.py`](diffhunk://#diff-14470160d981b140eb73b28994138ed344e5649e271cf511a6f420142e2acf9eL59-L63): Removed the test case `test_validate_media_with_http_path` which checked for the `ValueError` when an HTTP path was provided.

Closes #16 