### PR TITLE
feat: enhance AudioAsset and ImageAsset to support remote file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mosaico"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 description = "Open-source video generation framework"
 authors = [
     { name = "Leonardo Diegues", email = "leonardo.diegues@grupofolha.com.br" },

--- a/src/mosaico/assets/image.py
+++ b/src/mosaico/assets/image.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 
 from mosaico.assets.base import BaseAsset
 from mosaico.assets.utils import check_user_provided_required_keys
+from mosaico.media import _load_file
 from mosaico.positioning import AbsolutePosition, Position
 from mosaico.types import PathLike
 
@@ -100,9 +101,12 @@ class ImageAsset(BaseAsset[ImageAssetParams]):
         :param kwargs: Additional keyword arguments to the constructor.
         :return: The assets.
         """
+        storage_options = kwargs.pop("storage_options", None)
+
         if not check_user_provided_required_keys(kwargs, ["width", "height"]):
-            with Image.open(path) as img:
-                kwargs["width"], kwargs["height"] = img.size
+            raw_image = _load_file(path, storage_options)
+            with Image.open(io.BytesIO(raw_image)) as image:
+                kwargs["width"], kwargs["height"] = image.size
 
         return super().from_path(
             path, encoding=encoding, mime_type=mime_type, guess_mime_type=guess_mime_type, metadata=metadata, **kwargs

--- a/tests/assets/test_image.py
+++ b/tests/assets/test_image.py
@@ -108,3 +108,43 @@ def test_image_asset_with_metadata(sample_image_data):
     image_asset = ImageAsset.from_data(sample_image_data, metadata=metadata)
 
     assert image_asset.metadata == metadata
+
+
+# def test_image_asset_from_remote_path(mocker, sample_image_data):
+#     # Mock the _load_file function to simulate remote file loading
+#     mock_load_file = mocker.patch("mosaico.media._load_file")
+#     mock_load_file.return_value = sample_image_data
+
+#     remote_path = "https://f.i.uol.com.br/fotografia/2022/02/09/16444170036203cfeb9fbd1_1644417003_3x2_md.jpg"
+#     image_asset = ImageAsset.from_path(remote_path)
+
+#     assert image_asset.type == "image"
+#     assert image_asset.width == 100
+#     assert image_asset.height == 50
+#     assert image_asset.to_bytes() == sample_image_data
+
+
+# def test_image_asset_from_remote_path_with_explicit_dimensions(mocker, sample_image_data):
+#     # Mock the _load_file function to simulate remote file loading
+#     mock_load_file = mocker.patch("mosaico.media._load_file")
+#     mock_load_file.return_value = sample_image_data
+
+#     remote_path = "https://f.i.uol.com.br/fotografia/2022/02/09/16444170036203cfeb9fbd1_1644417003_3x2_md.jpg"
+#     image_asset = ImageAsset.from_path(remote_path, width=300, height=150)
+
+#     assert image_asset.width == 300
+#     assert image_asset.height == 150
+#     assert image_asset.to_bytes() == sample_image_data
+
+
+# def test_image_asset_from_remote_path_with_metadata(mocker, sample_image_data):
+#     # Mock the _load_file function to simulate remote file loading
+#     mock_load_file = mocker.patch("mosaico.media._load_file")
+#     mock_load_file.return_value = sample_image_data
+
+#     remote_path = "https://f.i.uol.com.br/fotografia/2022/02/09/16444170036203cfeb9fbd1_1644417003_3x2_md.jpg"
+#     metadata = {"author": "Test User", "created": "2023-01-01"}
+#     image_asset = ImageAsset.from_path(remote_path, metadata=metadata)
+
+#     assert image_asset.metadata == metadata
+#     assert image_asset.to_bytes() == sample_image_data

--- a/uv.lock
+++ b/uv.lock
@@ -1219,7 +1219,7 @@ wheels = [
 
 [[package]]
 name = "mosaico"
-version = "0.1.0rc4"
+version = "0.1.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "findsystemfontsfilename" },


### PR DESCRIPTION
This pull request includes several changes to enhance the handling of storage options when loading files and to improve the test coverage for image assets. The most important changes include adding storage options to the `from_path` and `slice` methods in `audio.py` and `image.py`, and updating the test cases in `test_image.py`.

Enhancements to file handling:

* [`src/mosaico/assets/audio.py`](diffhunk://#diff-f124ef6284cb6591f111faf8fc8e7761762daf77ec190294eae23313408a0a82R98-R118): Added `storage_options` parameter to the `from_path` and `slice` methods to allow for custom storage configurations.
* [`src/mosaico/assets/image.py`](diffhunk://#diff-f1cc6f99b1a1ba34241a039b62f49ab2116cf0233bd1701e5b14fe48cf034bc1R104-R109): Added `storage_options` parameter to the `from_path` method to support custom storage configurations.

Test coverage improvements:

* [`tests/assets/test_image.py`](diffhunk://#diff-5c378f6901230f09d5781116b55f32a8459c1a669be47ee168e35252e4167e8cR111-R150): Added commented-out test cases for loading image assets from remote paths, including tests with explicit dimensions and metadata. These tests simulate remote file loading by mocking the `_load_file` function.

Closes #18 