### PR TITLE
docs,fix: fix examples and lock moviepy version for now 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Mosaico is a Python library for programmatically creating and managing video com
 pip install mosaico
 ```
 
+To install script generator, speech synthesizer or audio transcriber dependencies, use:
+
+```bash
+pip install "mosaico[news]"
+```
+
+For additional dependencies, see the [additional dependencies](https://folhasp.github.io/mosaico/installation#additional-dependencies) section in the documentation.
+
 ## Features
 
 - AI-powered script generation for videos
@@ -28,11 +36,19 @@ pip install mosaico
 Easily create and render a video project from a script generator:
 
 ```python
+import os
+
 from mosaico.audio_transcribers.assemblyai import AssemblyAIAudioTranscriber
 from mosaico.script_generators.news import NewsVideoScriptGenerator
 from mosaico.speech_synthesizers.elevenlabs import ElevenLabsSpeechSynthesizer
 from mosaico.video.project import VideoProject
 from mosaico.video.rendering import render_video
+
+
+# Set your API keys
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
+ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 
 
 # Import your media
@@ -51,6 +67,7 @@ script_generator = NewsVideoScriptGenerator(
     context=context,
     language="pt",
     num_paragraphs=8,
+    api_key=ANTHROPIC_API_KEY,
 )
 
 # Create speech synthesizer
@@ -59,10 +76,11 @@ speech_synthesizer = ElevenLabsSpeechSynthesizer(
     voice_stability=0.8,
     voice_similarity_boost=0.75,
     voice_speaker_boost=False,
+    api_key=ELEVENLABS_API_KEY,
 )
 
 # Create audio transcriber for captions
-audio_transcriber = AssemblyAIAudioTranscriber()
+audio_transcriber = AssemblyAIAudioTranscriber(api_key=ASSEMBLYAI_API_KEY)
 
 # Create project
 project = (
@@ -75,7 +93,7 @@ project = (
 )
 
 # Render project
-render_video(project, "My-Breaking-News-Video.mp4")
+render_video(project, "path/to/dir")
 ```
 
 Or create a video project from scratch:
@@ -122,7 +140,7 @@ project = (
 )
 
 # Render project
-render_video(project, "My-Breaking-News-Video.mp4")
+render_video(project, "path/to/dir")
 ```
 
 ## Cookbook

--- a/docs/getting-started/installation.en.md
+++ b/docs/getting-started/installation.en.md
@@ -88,3 +88,28 @@ git clone https://github.com/folhalab/mosaico.git
 cd mosaico
 pip install -e .
 ```
+
+### Additional Dependencies
+
+To install optional dependencies for __Mosaico__, use the following command, replacing `news` with the desired feature or concatenating multiple features separated by commas:
+
+=== "Single feature"
+
+    ```bash
+    pip install "mosaico[news]"
+    ```
+
+=== "Multiple features"
+
+    ```bash
+    pip install "mosaico[news,elevenlabs,assemblyai]"
+    ```
+
+Available features and their dependencies are listed below:
+
+| Feature      	| Component                             	| Dependencies            	| Description                                                               	|
+|--------------	|---------------------------------------	|-------------------------	|---------------------------------------------------------------------------	|
+| `news`       	| script generator                      	| `litellm`, `instructor` 	| AI-powered script generation for videos                                   	|
+| `openai`     	| speech synthesizer, audio transcriber 	| `openai`                	| Text-to-speech synthesis and audio transcription integrations with OpenAI 	|
+| `elevenlabs` 	| speech synthesizer                    	| `elevenlabs`            	| Text-to-speech synthesis integration with ElevenLabs                      	|
+| `assemblyai` 	| audio transcriber                     	| `assemblyai`            	| Audio transcription integration with AssemblyAI                           	|

--- a/docs/getting-started/installation.pt.md
+++ b/docs/getting-started/installation.pt.md
@@ -88,3 +88,28 @@ git clone https://github.com/folhalab/mosaico.git
 cd mosaico
 pip install -e .
 ```
+
+### Dependências Adicionais
+
+Para instalar dependências opcionais para o __Mosaico__, use o seguinte comando, substituindo `news` pelo recurso desejado ou concatenando múltiplos recursos separados por vírgulas:
+
+=== "Recurso único"
+
+    ```bash
+    pip install "mosaico[news]"
+    ```
+
+=== "Múltiplos recursos"
+
+    ```bash
+    pip install "mosaico[news,elevenlabs,assemblyai]"
+    ```
+
+Os recursos disponíveis e suas dependências estão listados abaixo:
+
+| Recurso     	| Componente                            	| Dependências           	| Descrição                                                                 	|
+|-------------	|---------------------------------------	|-----------------------	|---------------------------------------------------------------------------	|
+| `news`      	| gerador de script                     	| `litellm`, `instructor`	| Geração de scripts para vídeos baseada em IA                             	|
+| `openai`    	| sintetizador de fala, transcritor de áudio	| `openai`          	| Integrações de síntese de texto para fala e transcrição de áudio com OpenAI	|
+| `elevenlabs`	| sintetizador de fala                  	| `elevenlabs`          	| Integração de síntese de texto para fala com ElevenLabs                   	|
+| `assemblyai`	| transcritor de áudio                  	| `assemblyai`          	| Integração de transcrição de áudio com AssemblyAI                         	|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
   - admonition
   - attr_list
   - md_in_html
+  - tables
 
 extra:
   generator: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "pydantic",
     "pyyaml",
-    "moviepy>=2.0.0.dev2",
+    "moviepy==2.0.0.dev2",
     "opencv-python>=4.10.0.84",
     "findsystemfontsfilename>=0.3.0",
     "pydub>=0.25.1",
@@ -41,9 +41,10 @@ mosaico = "mosaico.cli:entrypoint"
 [project.optional-dependencies]
 cli = ["click>=8.1.7"]
 assemblyai = ["assemblyai>=0.34.0"]
+elevenlabs = ["elevenlabs>=1.9.0"]
+openai = ["openai>=1.54.4"]
 langchain = ["langchain>=0.3.7"]
 haystack = ["haystack-ai>=2.6.1"]
-elevenlabs = ["elevenlabs>=1.9.0"]
 news = ["instructor>=1.6.4", "litellm>=1.52.9"]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1219,7 +1219,7 @@ wheels = [
 
 [[package]]
 name = "mosaico"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "findsystemfontsfilename" },
@@ -1253,6 +1253,9 @@ langchain = [
 news = [
     { name = "instructor" },
     { name = "litellm" },
+]
+openai = [
+    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -1288,7 +1291,8 @@ requires-dist = [
     { name = "instructor", marker = "extra == 'news'", specifier = ">=1.6.4" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.7" },
     { name = "litellm", marker = "extra == 'news'", specifier = ">=1.52.9" },
-    { name = "moviepy", specifier = ">=2.0.0.dev2" },
+    { name = "moviepy", specifier = "==2.0.0.dev2" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.54.4" },
     { name = "opencv-python", specifier = ">=4.10.0.84" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic" },


### PR DESCRIPTION
This pull request updates the `README.md` and documentation files to include information about installing optional dependencies and setting API keys. It also makes changes to the `pyproject.toml` file to adjust dependency versions and add new optional dependencies.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R24): Added instructions for installing optional dependencies and setting API keys for script generation, speech synthesizer, and audio transcriber. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R83) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R96) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R143)
* [`docs/getting-started/installation.en.md`](diffhunk://#diff-24d928507924a4651e4b7c77840f37c528f37b1173baa4b7e8021e305dad5b6eR91-R115): Added a section on installing additional dependencies with examples for single and multiple features.
* [`docs/getting-started/installation.pt.md`](diffhunk://#diff-7d81f19d53bfd3badee9d54b49673e6e595dd811ff829af145f313c25c28f5b0R91-R115): Added a section on installing additional dependencies with examples for single and multiple features in Portuguese.

Configuration updates:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R72): Added `tables` to the list of markdown extensions.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L28-R28): Updated the version of `moviepy` dependency and added `elevenlabs` and `openai` to optional dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L28-R28) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R44-L46)

Closes #20, closes #21, closes #22 