### PR TITLE
refactor: improve font handling and add system-aware font fallbacks

### DIFF
--- a/src/mosaico/assets/text.py
+++ b/src/mosaico/assets/text.py
@@ -17,7 +17,7 @@ class TextAssetParams(BaseModel):
     position: Position = Field(default_factory=AbsolutePosition)
     """The positioning of the text assets in the video."""
 
-    font_family: str = "Arial Bold"
+    font_family: str | None = None
     """The font family."""
 
     font_size: NonNegativeInt = 70

--- a/tests/clip_makers/test_text.py
+++ b/tests/clip_makers/test_text.py
@@ -1,0 +1,99 @@
+import pytest
+from PIL import ImageFont
+
+from mosaico.clip_makers.text import (
+    SystemFont,
+    _get_font_text_size,
+    _get_system_fallback_font_name,
+    _list_system_fonts,
+    _load_font,
+    _slugify_font_name,
+    _wrap_text,
+)
+
+
+def test_system_font_properties():
+    """Test SystemFont class properties."""
+    font = SystemFont(path="/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+
+    assert font.name == "DejaVuSans-Bold"
+    assert font.slug == "dejavusans-bold"
+    assert font.matches("DejaVuSans-Bold")
+    assert font.matches("dejavusans-bold")
+
+
+def test_slugify_font_name():
+    """Test font name slugification."""
+    test_cases = [
+        ("Arial Bold", "arial-bold"),
+        ("Times_New_Roman", "times-new-roman"),
+        ("Helvetica-Neue", "helvetica-neue"),
+        ("Open Sans Regular", "open-sans-regular"),
+        ("Font!!With@@Special##Chars", "fontwithspecialchars"),
+    ]
+
+    for input_name, expected_output in test_cases:
+        assert _slugify_font_name(input_name) == expected_output
+
+
+@pytest.mark.integration
+def test_list_system_fonts():
+    """Test system fonts listing."""
+    fonts = _list_system_fonts()
+
+    assert isinstance(fonts, list)
+    assert len(fonts) > 0
+    assert all(isinstance(font, SystemFont) for font in fonts)
+
+
+@pytest.mark.integration
+def test_load_font():
+    """Test font loading."""
+    # Test with default size
+    font = _load_font(_get_system_fallback_font_name(), 12)
+    assert isinstance(font, ImageFont.FreeTypeFont)
+
+    # Test with non-existent font (should return default font)
+    font = _load_font("NonExistentFont", 12)
+    assert isinstance(font, ImageFont.FreeTypeFont)
+
+
+@pytest.mark.integration
+def test_get_system_fallback_font():
+    """Test system fallback font retrieval."""
+    fallback_font = _get_system_fallback_font_name()
+    assert isinstance(fallback_font, str)
+    assert len(fallback_font) > 0
+
+
+def test_wrap_text():
+    """Test text wrapping functionality."""
+    font = _load_font(_get_system_fallback_font_name(), 12)
+    text = "This is a very long text that should be wrapped properly"
+
+    wrapped = _wrap_text(text, font, 100)
+    assert isinstance(wrapped, str)
+    assert "\n" in wrapped
+
+
+@pytest.mark.integration
+def test_text_size_calculation():
+    """Test text size calculation."""
+    font = _load_font(_get_system_fallback_font_name(), 12)
+    text = "Test text"
+
+    width, height = _get_font_text_size(text, font)
+    assert isinstance(width, int)
+    assert isinstance(height, int)
+    assert width > 0
+    assert height > 0
+
+
+@pytest.mark.integration
+def test_font_matching():
+    """Test font matching functionality."""
+    font = SystemFont("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+
+    assert font.matches("DejaVuSans-Bold")
+    assert font.matches("dejavusans-bold")
+    assert not font.matches("Arial")


### PR DESCRIPTION
This pull request introduces multiple changes to improve the handling of font properties and text rendering in the `mosaico` package. The most important changes include modifying the `TextAssetParams` class, adding a new `SystemFont` class, and updating the text clip creation logic. Additionally, new utility functions and tests have been added to support these changes.

### Font handling improvements:

* [`src/mosaico/assets/text.py`](diffhunk://#diff-0d9442a24658ee897eb20f365f92483fe3bd9169471422a9ef4dcf926964a9faL20-R20): Changed the `font_family` attribute in `TextAssetParams` to allow `None` values, enabling fallback font logic.
* [`src/mosaico/clip_makers/text.py`](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R4-L9): Introduced a new `SystemFont` class to represent system fonts and added utility functions for listing system fonts, slugifying font names, and retrieving fallback font names. [[1]](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R4-L9) [[2]](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R151-R239)
* [`src/mosaico/clip_makers/text.py`](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R92-R95): Updated the `_make_clip` method to set a fallback font if `font_family` is `None` and refactored the `_load_font` function to use the new `SystemFont` class. [[1]](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R92-R95) [[2]](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R151-R239)

### Tests for new functionality:

* [`tests/clip_makers/test_text.py`](diffhunk://#diff-12331c9b81fb71f5b6e19f8106e86560e5ccdfefd69cef1cf22badea465c3a05R1-R99): Added tests for the `SystemFont` class properties, font name slugification, system font listing, font loading, fallback font retrieval, text wrapping, text size calculation, and font matching.

Closes #28, closes #29 