### PR TITLE
refactor: improve file handling in VideoProject methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ ignore = [
 "src/mosaico/assets/factory.py" = ["A002"]
 "src/mosaico/video/project_builder.py" = ["C901", "PLR0912"]
 "src/mosaico/speech_synthesizers/*.py" = ["D102"]
+"src/mosaico/types.py" = ["D102"]
+"src/mosaico/**/prompts.py" = ["E501"]
 "cookbook/*.py" = ["F821"]
 "tests/*.py" = ["S101", "D", "ARG001", "PLR2004"]
 

--- a/src/mosaico/assets/audio.py
+++ b/src/mosaico/assets/audio.py
@@ -13,7 +13,7 @@ from typing_extensions import Self
 from mosaico.assets.base import BaseAsset
 from mosaico.assets.utils import check_user_provided_required_keys
 from mosaico.media import _load_file
-from mosaico.types import PathLike
+from mosaico.types import FilePath
 
 
 class AudioAssetParams(BaseModel):
@@ -52,7 +52,7 @@ class AudioAsset(BaseAsset[AudioAssetParams]):
         cls,
         data: str | bytes,
         *,
-        path: PathLike | None = None,
+        path: FilePath | None = None,
         metadata: dict | None = None,
         mime_type: str | None = None,
         **kwargs: Any,
@@ -76,7 +76,7 @@ class AudioAsset(BaseAsset[AudioAssetParams]):
     @classmethod
     def from_path(
         cls,
-        path: PathLike,
+        path: FilePath,
         *,
         encoding: str = "utf-8",
         mime_type: str | None = None,
@@ -137,7 +137,7 @@ class AudioAsset(BaseAsset[AudioAssetParams]):
             )
 
 
-def _extract_audio_info(audio: PathLike | bytes) -> dict:
+def _extract_audio_info(audio: FilePath | bytes) -> dict:
     """
     Extracts the audio information from the audio data.
     """

--- a/src/mosaico/assets/factory.py
+++ b/src/mosaico/assets/factory.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from mosaico.assets.subtitle import SubtitleAsset
     from mosaico.assets.text import TextAsset, TextAssetParams
     from mosaico.assets.types import Asset, AssetParams, AssetType
-    from mosaico.types import PathLike
+    from mosaico.types import FilePath
 
 
 @overload
@@ -21,7 +21,7 @@ def create_asset(
     asset_type: Literal["image"],
     id: str | None = ...,
     data: str | bytes | None = ...,
-    path: PathLike | None = ...,
+    path: FilePath | None = ...,
     metadata: dict[str, Any] | None = ...,
     params: ImageAssetParams | None = ...,
     **kwargs: Any,
@@ -33,7 +33,7 @@ def create_asset(
     asset_type: Literal["audio"],
     id: str | None = ...,
     data: str | bytes | None = ...,
-    path: PathLike | None = ...,
+    path: FilePath | None = ...,
     metadata: dict[str, Any] | None = ...,
     params: AudioAssetParams | None = ...,
     **kwargs: Any,
@@ -45,7 +45,7 @@ def create_asset(
     asset_type: Literal["text"],
     id: str | None = ...,
     data: str | bytes | None = ...,
-    path: PathLike | None = ...,
+    path: FilePath | None = ...,
     metadata: dict[str, Any] | None = ...,
     params: TextAssetParams | None = ...,
     **kwargs: Any,
@@ -57,7 +57,7 @@ def create_asset(
     asset_type: Literal["subtitle"],
     id: str | None = ...,
     data: str | bytes | None = ...,
-    path: PathLike | None = ...,
+    path: FilePath | None = ...,
     metadata: dict[str, Any] | None = ...,
     params: TextAssetParams | None = ...,
     **kwargs: Any,
@@ -69,7 +69,7 @@ def create_asset(
     asset_type: AssetType,
     id: str | None = ...,
     data: str | bytes | None = ...,
-    path: PathLike | None = ...,
+    path: FilePath | None = ...,
     metadata: dict[str, Any] | None = ...,
     params: AssetParams | None = ...,
     **kwargs: Any,
@@ -80,7 +80,7 @@ def create_asset(
     asset_type: AssetType,
     id: str | None = None,
     data: str | bytes | None = None,
-    path: PathLike | None = None,
+    path: FilePath | None = None,
     metadata: dict[str, Any] | None = None,
     params: AssetParams | dict[str, Any] | None = None,
     **kwargs: Any,

--- a/src/mosaico/assets/image.py
+++ b/src/mosaico/assets/image.py
@@ -14,7 +14,7 @@ from mosaico.assets.base import BaseAsset
 from mosaico.assets.utils import check_user_provided_required_keys
 from mosaico.media import _load_file
 from mosaico.positioning import AbsolutePosition, Position
-from mosaico.types import PathLike
+from mosaico.types import FilePath
 
 
 class ImageAssetParams(BaseModel):
@@ -55,7 +55,7 @@ class ImageAsset(BaseAsset[ImageAssetParams]):
         cls,
         data: str | bytes,
         *,
-        path: PathLike | None = None,
+        path: FilePath | None = None,
         metadata: dict | None = None,
         mime_type: str | None = None,
         **kwargs: Any,
@@ -82,7 +82,7 @@ class ImageAsset(BaseAsset[ImageAssetParams]):
     @classmethod
     def from_path(
         cls,
-        path: PathLike,
+        path: FilePath,
         *,
         encoding: str = "utf-8",
         mime_type: str | None = None,

--- a/src/mosaico/assets/reference.py
+++ b/src/mosaico/assets/reference.py
@@ -94,7 +94,7 @@ class AssetReference(BaseModel):
             msg = "Missing 'asset_type' key in asset reference data."
             raise ValueError(msg)
 
-        if "asset_params" in data:
+        if "asset_params" in data and data["asset_params"] is not None:
             params_cls = get_asset_params_class(data["asset_type"])
             data["asset_params"] = params_cls.model_validate(data["asset_params"])
 

--- a/src/mosaico/media.py
+++ b/src/mosaico/media.py
@@ -15,7 +15,7 @@ from pydantic.functional_validators import model_validator
 from typing_extensions import Self
 
 from mosaico.integrations.base.adapters import Adapter
-from mosaico.types import PathLike
+from mosaico.types import FilePath
 
 
 class Media(BaseModel):
@@ -29,7 +29,7 @@ class Media(BaseModel):
     data: str | bytes | None = None
     """The content of the media."""
 
-    path: PathLike | None = None
+    path: FilePath | None = None
     """The path to the media."""
 
     mime_type: str | None = None
@@ -71,7 +71,7 @@ class Media(BaseModel):
     @classmethod
     def from_path(
         cls,
-        path: PathLike,
+        path: FilePath,
         *,
         encoding: str = "utf-8",
         mime_type: str | None = None,
@@ -107,7 +107,7 @@ class Media(BaseModel):
         cls,
         data: str | bytes,
         *,
-        path: PathLike | None = None,
+        path: FilePath | None = None,
         metadata: dict | None = None,
         mime_type: str | None = None,
         **kwargs: Any,
@@ -187,8 +187,8 @@ class Media(BaseModel):
 
 
 def _yield_file(
-    path: PathLike, storage_options: dict[str, Any] | None = None
-) -> Generator[io.BufferedReader, None, None]:
+    path: FilePath, storage_options: dict[str, Any] | None = None
+) -> Generator[io.BufferedReader]:
     """
     Yields a file from a path.
     """
@@ -197,7 +197,7 @@ def _yield_file(
         yield f  # type: ignore
 
 
-def _load_file(path: PathLike, storage_options: dict[str, Any] | None = None) -> bytes:
+def _load_file(path: FilePath, storage_options: dict[str, Any] | None = None) -> bytes:
     """
     Loads a file from a path.
     """

--- a/src/mosaico/script_generators/news/prompts.py
+++ b/src/mosaico/script_generators/news/prompts.py
@@ -41,8 +41,7 @@ MEDIA_SUGGESTING_PROMPT = textwrap.dedent(
     - The video should be dynamic, so be sure to select different media objects for different shots.
     - Only select media objects that are available in the provided collection
     - Each media object should be used only once.
-    - If there are characters, places, or things in the paragraph, select a media object that shows the character, place,
-    or thing.
+    - If there are characters, places, or things in the paragraph, select a media object that shows the character, place, or thing.
     - Answer only with the structured response format in the same language as the paragraphs.
 
     EXAMPLE:
@@ -71,7 +70,7 @@ MEDIA_SUGGESTING_PROMPT = textwrap.dedent(
 
     AVAILABLE MEDIA OBJECTS:
     {media_objects}
- 
+
     PARAGRAPHS:
     {paragraphs}
 

--- a/src/mosaico/types.py
+++ b/src/mosaico/types.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from pathlib import PurePath
-from typing import Annotated
+from pathlib import Path
+from typing import Annotated, Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic.fields import Field
 
 
-PathLike = str | PurePath
+FilePath = str | Path
 """A type alias for paths."""
 
 FrameSize = tuple[int, int]
@@ -14,3 +14,49 @@ FrameSize = tuple[int, int]
 
 ModelTemperature = Annotated[float, Field(ge=0, le=1)]
 """A type alias for model temperatures."""
+
+
+# Buffer protocols stolen from pandas, with some minor modifications:
+# https://github.com/pandas-dev/pandas/blob/a4e814954b6f1c41528c071b028df62def7765c0/pandas/_typing.py#L266C1-L304C1
+
+# filenames and file-like-objects
+AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)
+AnyStr_contra = TypeVar("AnyStr_contra", str, bytes, contravariant=True)
+
+
+class BaseBuffer(Protocol):
+    @property
+    def mode(self) -> str:
+        # for _get_filepath_or_buffer
+        ...
+
+    def seek(self, offset: int, whence: int = ..., /) -> int:
+        # with one argument: gzip.GzipFile, bz2.BZ2File
+        # with two arguments: zip.ZipFile, read_sas
+        ...
+
+    def seekable(self) -> bool:
+        # for bz2.BZ2File
+        ...
+
+    def tell(self) -> int:
+        # for zip.ZipFile, read_stata, to_stata
+        ...
+
+
+@runtime_checkable
+class ReadableBuffer(BaseBuffer, Protocol[AnyStr_co]):
+    def read(self, n: int = ..., /) -> AnyStr_co:
+        # for BytesIOWrapper, gzip.GzipFile, bz2.BZ2File
+        ...
+
+
+@runtime_checkable
+class WritableBuffer(BaseBuffer, Protocol[AnyStr_contra]):
+    def write(self, b: AnyStr_contra, /) -> Any:
+        # for gzip.GzipFile, bz2.BZ2File
+        ...
+
+    def flush(self) -> Any:
+        # for gzip.GzipFile, bz2.BZ2File
+        ...


### PR DESCRIPTION
This pull request includes several changes to the `mosaico` project, focusing on refactoring type aliases, updating function signatures, and improving test coverage. The most important changes include replacing the `PathLike` type alias with `FilePath`, updating related function signatures, and enhancing test functions to support in-memory file operations.

### Type Alias Refactoring:
* Replaced `PathLike` with `FilePath` in `src/mosaico/types.py` and updated all related imports and function signatures across multiple files. [[1]](diffhunk://#diff-f124ef6284cb6591f111faf8fc8e7761762daf77ec190294eae23313408a0a82L16-R16) [[2]](diffhunk://#diff-7c65042e219935460fd2e29d4372bd02fd479329ede977a502fb83841387246cL16-R24) [[3]](diffhunk://#diff-f1cc6f99b1a1ba34241a039b62f49ab2116cf0233bd1701e5b14fe48cf034bc1L17-R17) [[4]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL18-R18) [[5]](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L29-R29)

### Function Signature Updates:
* Updated function signatures in `src/mosaico/assets/audio.py`, `src/mosaico/assets/factory.py`, `src/mosaico/assets/image.py`, and `src/mosaico/media.py` to use `FilePath` instead of `PathLike`. [[1]](diffhunk://#diff-f124ef6284cb6591f111faf8fc8e7761762daf77ec190294eae23313408a0a82L55-R55) [[2]](diffhunk://#diff-7c65042e219935460fd2e29d4372bd02fd479329ede977a502fb83841387246cL36-R36) [[3]](diffhunk://#diff-f1cc6f99b1a1ba34241a039b62f49ab2116cf0233bd1701e5b14fe48cf034bc1L58-R58) [[4]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL32-R32)

### Enhanced Test Coverage:
* Added tests in `tests/video/test_project.py` to support in-memory file operations using `io.StringIO`, ensuring compatibility with both file paths and file-like objects. [[1]](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdR200-R211) [[2]](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdR224-R230)

### Code Cleanup:
* Fixed a long line in `src/mosaico/script_generators/news/prompts.py` to adhere to style guidelines.

### Minor Fixes:
* Added a check for `None` in `src/mosaico/assets/reference.py` to prevent errors when `asset_params` is missing.