### PR TITLE
fix: news script generator prompt inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format:
 # Executa casos de teste
 .PHONY: test
 test:
-	uv run pytest
+	uv run pytest tests
 
 .PHONY: e2e
 e2e:

--- a/src/mosaico/script_generators/news/prompts.py
+++ b/src/mosaico/script_generators/news/prompts.py
@@ -88,7 +88,8 @@ SHOOTING_SCRIPT_PROMPT = textwrap.dedent(
     - Keep the paragraphs and media objects as they are. Avoid changing them.
     - Use the paragraphs as subtitles for the shots.
     - Add timings to the media objects. Make sure they do not overlap.
-    - Respond only with the structured output format in the same language as the paragraphs.
+    - Add a title for the shooting script.
+    - Respond only with the structured JSON output format in the same language as the paragraphs.
 
     SHOOTING SCRIPT:
     """


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and `src/mosaico/script_generators/news/generator.py` files to improve testing, enhance media suggestions, and update prompt formatting. The most important changes are summarized below:

### Testing improvements:
* Modified the `test` target in the `Makefile` to specify the `tests` directory when running pytest.

### Enhancements to media suggestions:
* Added `Field` import from `pydantic.fields` in `src/mosaico/script_generators/news/generator.py` to use default factory for list fields.
* Updated `ParagraphMediaSuggestions` class to use `Field` with `default_factory` for the `suggestions` attribute.
* Changed the `_summarize_context` method to expect a list of strings as the response type from `_fetch_completion`.
* Enhanced `_suggest_paragraph_media` and `_generate_shooting_script` methods to format prompts more effectively for media suggestions and shooting script generation.

### Prompt formatting updates:
* Updated the shooting script prompt to include a title and specify the response format as structured JSON.