### PR TITLE
fix: set default title for shooting script to "Untitled"

### DIFF
--- a/src/mosaico/script_generators/script.py
+++ b/src/mosaico/script_generators/script.py
@@ -75,7 +75,7 @@ class Shot(BaseModel):
 class ShootingScript(BaseModel):
     """A shooting script for a video project."""
 
-    title: str
+    title: str = "Untitled"
     """The title of the script."""
 
     description: str | None = None


### PR DESCRIPTION
This pull request includes a small change to the `src/mosaico/script_generators/script.py` file. The change sets a default value for the `title` attribute in the `ShootingScript` class.

* [`src/mosaico/script_generators/script.py`](diffhunk://#diff-3145b7327689da0c3cb1e791cac4830025e370316f93dd76dd760692e42642c8L78-R78): Added a default value of "Untitled" to the `title` attribute in the `ShootingScript` class.

Closes #39 