### PR TITLE
feat: add fade effects to VideoEffect and VideoEffectType

### DIFF
--- a/src/mosaico/effects/types.py
+++ b/src/mosaico/effects/types.py
@@ -1,11 +1,21 @@
 from typing import Literal
 
+from mosaico.effects.fade import FadeInEffect, FadeOutEffect
 from mosaico.effects.pan import PanDownEffect, PanLeftEffect, PanRightEffect, PanUpEffect
 from mosaico.effects.zoom import ZoomInEffect, ZoomOutEffect
 
 
-VideoEffect = ZoomInEffect | ZoomOutEffect | PanLeftEffect | PanRightEffect | PanUpEffect | PanDownEffect
+VideoEffect = (
+    ZoomInEffect
+    | ZoomOutEffect
+    | PanLeftEffect
+    | PanRightEffect
+    | PanUpEffect
+    | PanDownEffect
+    | FadeInEffect
+    | FadeOutEffect
+)
 """A type representing any video effect."""
 
-VideoEffectType = Literal["zoom_in", "zoom_out", "pan_left", "pan_right", "pan_up", "pan_down"]
+VideoEffectType = Literal["zoom_in", "zoom_out", "pan_left", "pan_right", "pan_up", "pan_down", "fade_in", "fade_out"]
 """A type representing the type of a video effect."""


### PR DESCRIPTION
This pull request includes updates to the `src/mosaico/effects/types.py` file to add new video effects and their types.

Enhancements to video effects:

* Added `FadeInEffect` and `FadeOutEffect` to the `VideoEffect` type.
* Updated `VideoEffectType` to include "fade_in" and "fade_out" literals.

Closes #41 