### PR TITLE
fix: add fade in and fade out effects to the effect factory

### DIFF
--- a/src/mosaico/effects/factory.py
+++ b/src/mosaico/effects/factory.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from mosaico.effects.fade import FadeInEffect, FadeOutEffect
 from mosaico.effects.pan import PanDownEffect, PanLeftEffect, PanRightEffect, PanUpEffect
 from mosaico.effects.protocol import Effect
 from mosaico.effects.zoom import ZoomInEffect, ZoomOutEffect
@@ -12,6 +13,8 @@ EFFECT_MAP: dict[str, type[Effect]] = {
     "pan_down": PanDownEffect,
     "zoom_in": ZoomInEffect,
     "zoom_out": ZoomOutEffect,
+    "fade_in": FadeInEffect,
+    "fade_out": FadeOutEffect,
 }
 
 


### PR DESCRIPTION
This pull request includes updates to the `src/mosaico/effects/factory.py` file to add new fade effects to the effects factory.

New effects added:

* Imported `FadeInEffect` and `FadeOutEffect` from `mosaico.effects.fade` to the effects factory.
* Added `fade_in` and `fade_out` to the dictionary of effects in the factory.