### PR TITLE
fix: update clip layer setting method in _render_event_clips function

### DIFF
--- a/src/mosaico/video/rendering.py
+++ b/src/mosaico/video/rendering.py
@@ -123,7 +123,7 @@ def _render_event_clips(
 
         if hasattr(asset.params, "z_index"):
             layer = getattr(asset.params, "z_index")
-            clip = clip.set_layer(layer)
+            clip = clip.with_layer_index(layer)
 
         if isinstance(asset, AudioAsset):
             audio_clips.append(clip)


### PR DESCRIPTION
This pull request includes a small change to the `src/mosaico/video/rendering.py` file. The change involves updating the method used to set the layer index of a clip.

* [`src/mosaico/video/rendering.py`](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L126-R126): Replaced the `set_layer` method with the `with_layer_index` method for setting the layer index of a clip.

Closes #49 