### PR TITLE
feat: update render_video to support output path and codec-based file extensions

### DIFF
--- a/tests/video/test_rendering.py
+++ b/tests/video/test_rendering.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+
+from mosaico.video.rendering import render_video
+
+
+# Dummy classes to simulate a VideoProject and minimal dependencies.
+class DummyConfig:
+    title = "TestVideo"
+    resolution = (640, 480)
+    fps = 24
+
+
+class DummyProject:
+    def __init__(self):
+        self.config = DummyConfig()
+        self.duration = 10
+        self.timeline = []  # Keeping it empty, no events needed for these tests.
+
+    def get_asset(self, asset_id):
+        # Not used in our tests since timeline is empty.
+        return None
+
+
+# Dummy composite video clip to bypass actual Moviepy processing.
+class DummyCompositeVideoClip:
+    def __init__(self, clips, size):
+        self.clips = clips
+        self.size = size
+
+    def with_fps(self, fps):
+        return self
+
+    def with_duration(self, duration):
+        return self
+
+    def with_audio(self, audio):
+        return self
+
+    def write_videofile(self, path, **kwargs):
+        # Fake write; do nothing.
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def patch_moviepy(monkeypatch):
+    # Patch CompositeVideoClip used in render_video with our dummy clip.
+    monkeypatch.setattr("mosaico.video.rendering.CompositeVideoClip", DummyCompositeVideoClip)
+
+
+@pytest.fixture
+def dummy_project():
+    return DummyProject()
+
+
+def test_output_directory_not_exists(tmp_path, dummy_project):
+    # Create a path that is inside a non-existent directory.
+    non_existing_dir = tmp_path / "non_existing_folder"
+    output_file = non_existing_dir / "output.mp4"
+
+    with pytest.raises(FileNotFoundError, match="Output directory does not exist"):
+        render_video(dummy_project, output_file.as_posix())
+
+
+def test_file_already_exists(tmp_path, dummy_project):
+    # Create a valid directory with an existing file.
+    output_file = tmp_path / "output.mp4"
+    # Create file to simulate existing output.
+    output_file.touch()
+
+    with pytest.raises(FileExistsError, match="Output file already exists"):
+        render_video(dummy_project, output_file.as_posix(), overwrite=False)
+
+
+def test_incorrect_extension(tmp_path, dummy_project):
+    # Provide a valid directory but with wrong file extension.
+    output_file = tmp_path / "output.avi"  # Since default codec libx264 expects .mp4
+    # Ensure parent exists.
+    tmp_path.mkdir(exist_ok=True)
+    with pytest.raises(ValueError, match="Output file must be an '.mp4' file."):
+        render_video(dummy_project, output_file.as_posix())
+
+
+def test_successful_rendering(tmp_path, dummy_project):
+    # Provide a valid output file.
+    output_file = tmp_path / "output.mp4"
+    # Call render_video, should not raise and should return the output path.
+    returned_path = render_video(dummy_project, output_file.as_posix(), overwrite=False)
+    assert Path(returned_path) == output_file.resolve()
+    # Check that file is not created by our dummy rendering.
+    assert not output_file.exists()


### PR DESCRIPTION
This pull request introduces significant improvements to the `render_video` function in `src/mosaico/video/rendering.py` and adds comprehensive tests for the function in `tests/video/test_rendering.py`. The changes enhance the flexibility of the output path handling and ensure better error checking.

### Enhancements to `render_video` function:

* Added `_CODEC_FILE_EXTENSION_MAP` to map codecs to their respective file extensions.
* Changed the `output_dir` parameter to `output_path` to allow specifying either a file path or a directory path. Updated the function to handle these cases appropriately.
* Implemented additional error checking for output file extension and directory existence.

### Added tests for `render_video` function:

* Introduced dummy classes to simulate `VideoProject` and minimal dependencies, along with a dummy composite video clip to bypass actual Moviepy processing.
* Added tests to verify various scenarios including non-existent output directory, existing output file, incorrect file extension, and successful rendering.

Closes #23 