### PR TITLE
docs: enhance `render_video` function docstring to clarify output path and codec options

### DIFF
--- a/src/mosaico/video/rendering.py
+++ b/src/mosaico/video/rendering.py
@@ -42,7 +42,17 @@ def render_video(
     Renders a video based on a project.
 
     :param project: The project to render.
-    :param output_path: The output path. Could be a '.mp4' file path or a directory path.
+    :param output_path: The output path. If a directory is provided, the output file will be saved in the directory
+        with the project title as the filename. Otherwise, be sure that the file extension matches the codec used.
+        By default, the output file will be an MP4 file (H.264 codec). The available codecs are:
+
+        - libx264: .mp4
+        - mpeg4: .mp4
+        - rawvideo: .avi
+        - png: .avi
+        - libvorbis: .ogv
+        - libvpx: .webm
+
     :param storage_options: Optional storage options to pass to the clip.
     :param overwrite: Whether to overwrite the output file if it already exists.
     :param kwargs: Additional keyword arguments to pass to Moviepy clip video writer.


### PR DESCRIPTION
This pull request includes changes to the `render_video` function in `src/mosaico/video/rendering.py` to provide more detailed information on the output path and supported codecs.

Enhancements to `render_video` function:

* [`src/mosaico/video/rendering.py`](diffhunk://#diff-a2a811042ee95548ed5df5a53551b8e24e3e7ab076581400b42a8435639bb857L45-R55): Updated the `output_path` parameter description to include details on handling directory paths, default file format, and a list of available codecs with their corresponding file extensions.

Closes #54 