### PR TITLE
refactor: improve error handling for timeline event retrieval

### DIFF
--- a/src/mosaico/exceptions.py
+++ b/src/mosaico/exceptions.py
@@ -1,11 +1,26 @@
 class MosaicoException(Exception):
     """Base exception for all exceptions raised by Mosaico."""
 
-    pass
+
+class AssetNotFoundError(MosaicoException):
+    """Raised when an asset could not be found in the project."""
+
+    def __init__(self, asset_id: str) -> None:
+        self.asset_id = asset_id
+
+    def __str__(self) -> str:
+        return f"Asset with ID '{self.asset_id}' not found in the project assets."
+
+
+class TimelineEventNotFoundError(IndexError, MosaicoException):
+    """Raised when a timeline could not be found in the project."""
+
+    def __init__(self) -> None:
+        super().__init__("Timeline event index out of range.")
 
 
 class InvalidAssetTypeError(TypeError, MosaicoException):
     """Raised when an assets type is not supported."""
 
     def __init__(self, invalid_type: str) -> None:
-        super().__init__(f"Invalid asset type: {invalid_type}")
+        super().__init__(f"Invalid asset type: '{invalid_type}'")

--- a/src/mosaico/scene.py
+++ b/src/mosaico/scene.py
@@ -96,7 +96,7 @@ class Scene(BaseModel):
         self.asset_references.extend(references)
         return self
 
-    def remove_references_by_asset_id(self, asset_id: str) -> Scene:
+    def remove_asset_id_references(self, asset_id: str) -> Scene:
         """
         Remove asset references by asset ID.
 

--- a/tests/video/test_project.py
+++ b/tests/video/test_project.py
@@ -13,6 +13,7 @@ from mosaico.assets.reference import AssetReference
 from mosaico.assets.subtitle import SubtitleAsset
 from mosaico.assets.text import TextAsset, TextAssetParams
 from mosaico.audio_transcribers.transcription import Transcription, TranscriptionWord
+from mosaico.exceptions import AssetNotFoundError, TimelineEventNotFoundError
 from mosaico.media import Media
 from mosaico.scene import Scene
 from mosaico.script_generators.script import ShootingScript, Shot
@@ -140,8 +141,18 @@ def test_add_timeline_events_multiple_dict_scenes():
 
 def test_add_timeline_events_without_assets() -> None:
     event = AssetReference(asset_id="test", asset_type="text", start_time=0, end_time=10)
-    with pytest.raises(IndexError, match="Asset with ID 'test' not found in project assets"):
+    with pytest.raises(AssetNotFoundError, match="Asset with ID 'test' not found in the project assets"):
         VideoProject().add_timeline_events(event)
+
+
+def test_get_inexistent_timeline_event_error() -> None:
+    with pytest.raises(TimelineEventNotFoundError):
+        VideoProject().get_timeline_event(10)
+
+
+def test_remove_inexistent_timeline_event_error() -> None:
+    with pytest.raises(TimelineEventNotFoundError):
+        VideoProject().remove_timeline_event(10)
 
 
 def test_duration() -> None:
@@ -159,7 +170,7 @@ def test_get_asset() -> None:
     asset = TextAsset.from_data("test", id="asset1")
     project = VideoProject().add_assets(asset)
     assert project.get_asset("asset1") == asset
-    with pytest.raises(KeyError, match="Asset with ID 'nonexistent' not found in the project assets"):
+    with pytest.raises(AssetNotFoundError, match="Asset with ID 'nonexistent' not found in the project assets"):
         project.get_asset("nonexistent")
 
 


### PR DESCRIPTION
This pull request introduces several changes to improve error handling and code readability in the `mosaico` project. The most significant changes include the addition of new exception classes, refactoring of existing methods to use these new exceptions, and updates to the test cases to reflect these changes.

### Error Handling Improvements:

* [`src/mosaico/exceptions.py`](diffhunk://#diff-bc907ece89eeb6c4594aab90cd1d20480ff33698cd2b117de4f05cfd36b07166L4-R26): Added new exception classes `AssetNotFoundError` and `TimelineEventNotFoundError` to provide more specific error messages.

* [`src/mosaico/video/project.py`](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L226-L247): Refactored methods to use the new `AssetNotFoundError` and `TimelineEventNotFoundError` exceptions instead of generic `IndexError` and `KeyError`. [[1]](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L226-L247) [[2]](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L550-R545) [[3]](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L561-R569) [[4]](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L577-R587)

### Code Readability Enhancements:

* [`src/mosaico/scene.py`](diffhunk://#diff-d327462282b665d10151bfcf2e2fb5b0525426688fe67897bb8c5700dd9a8061L99-R99): Renamed the method `remove_references_by_asset_id` to `remove_asset_id_references` for better clarity.

### Test Case Updates:

* [`tests/video/test_project.py`](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdR16): Updated test cases to check for the new `AssetNotFoundError` and `TimelineEventNotFoundError` exceptions. Added new tests for these exceptions. [[1]](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdR16) [[2]](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdL143-R157) [[3]](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdL162-R173)

Closes #57 