### PR TITLE
feat: add video crossfade effects

### DIFF
--- a/src/mosaico/effects/crossfade.py
+++ b/src/mosaico/effects/crossfade.py
@@ -1,0 +1,40 @@
+from typing import Literal
+
+from moviepy.video import fx as vfx
+from moviepy.video.VideoClip import VideoClip
+
+from mosaico.effects.fade import BaseFadeEffect
+
+
+class CrossFadeInEffect(BaseFadeEffect):
+    """fade-in effect for video clips."""
+
+    type: Literal["crossfade_in"] = "crossfade_in"
+    """Effect type. Must be "crossfade_in"."""
+
+    def apply(self, clip: VideoClip) -> VideoClip:
+        """
+        Apply fade-in effect to clip.
+
+        :param clip: The clip to apply the effect to.
+        :return: The clip with the effect applied.
+        """
+        fx = vfx.CrossFadeIn(self.duration)
+        return fx.apply(clip)  # type: ignore
+
+
+class CrossFadeOutEffect(BaseFadeEffect):
+    """fade-out effect for video clips."""
+
+    type: Literal["crossfade_out"] = "crossfade_out"
+    """Effect type. Must be "crossfade_out"."""
+
+    def apply(self, clip: VideoClip) -> VideoClip:
+        """
+        Apply fade-out effect to clip.
+
+        :param clip: The clip to apply the effect to.
+        :return: The clip with the effect applied.
+        """
+        fx = vfx.CrossFadeOut(self.duration)
+        return fx.apply(clip)  # type: ignore

--- a/src/mosaico/effects/factory.py
+++ b/src/mosaico/effects/factory.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from mosaico.effects.crossfade import CrossFadeInEffect, CrossFadeOutEffect
 from mosaico.effects.fade import FadeInEffect, FadeOutEffect
 from mosaico.effects.pan import PanDownEffect, PanLeftEffect, PanRightEffect, PanUpEffect
 from mosaico.effects.protocol import Effect
@@ -15,6 +16,8 @@ EFFECT_MAP: dict[str, type[Effect]] = {
     "zoom_out": ZoomOutEffect,
     "fade_in": FadeInEffect,
     "fade_out": FadeOutEffect,
+    "crossfade_in": CrossFadeInEffect,
+    "crossfade_out": CrossFadeOutEffect,
 }
 
 

--- a/src/mosaico/effects/types.py
+++ b/src/mosaico/effects/types.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+from mosaico.effects.crossfade import CrossFadeInEffect, CrossFadeOutEffect
 from mosaico.effects.fade import FadeInEffect, FadeOutEffect
 from mosaico.effects.pan import PanDownEffect, PanLeftEffect, PanRightEffect, PanUpEffect
 from mosaico.effects.zoom import ZoomInEffect, ZoomOutEffect
@@ -14,8 +15,21 @@ VideoEffect = (
     | PanDownEffect
     | FadeInEffect
     | FadeOutEffect
+    | CrossFadeInEffect
+    | CrossFadeOutEffect
 )
 """A type representing any video effect."""
 
-VideoEffectType = Literal["zoom_in", "zoom_out", "pan_left", "pan_right", "pan_up", "pan_down", "fade_in", "fade_out"]
+VideoEffectType = Literal[
+    "zoom_in",
+    "zoom_out",
+    "pan_left",
+    "pan_right",
+    "pan_up",
+    "pan_down",
+    "fade_in",
+    "fade_out",
+    "crossfade_out",
+    "crossfade_in",
+]
 """A type representing the type of a video effect."""

--- a/tests/effects/test_factory.py
+++ b/tests/effects/test_factory.py
@@ -1,6 +1,8 @@
 import pytest
 
+from mosaico.effects.crossfade import CrossFadeInEffect, CrossFadeOutEffect
 from mosaico.effects.factory import EFFECT_MAP, create_effect
+from mosaico.effects.fade import FadeInEffect, FadeOutEffect
 from mosaico.effects.pan import PanDownEffect, PanLeftEffect, PanRightEffect, PanUpEffect
 from mosaico.effects.zoom import ZoomInEffect, ZoomOutEffect
 
@@ -14,6 +16,10 @@ from mosaico.effects.zoom import ZoomInEffect, ZoomOutEffect
         ("pan_down", PanDownEffect),
         ("zoom_in", ZoomInEffect),
         ("zoom_out", ZoomOutEffect),
+        ("fade_in", FadeInEffect),
+        ("fade_out", FadeOutEffect),
+        ("crossfade_in", CrossFadeInEffect),
+        ("crossfade_out", CrossFadeOutEffect),
     ],
 )
 def test_create_effect_valid(effect_type, expected_class):


### PR DESCRIPTION
This pull request introduces new crossfade effects for video clips and integrates them into the existing effect framework. The changes include adding the new effects, updating the effect factory to recognize them, and expanding the type definitions and tests to accommodate the new effects.

### New Crossfade Effects:
* [`src/mosaico/effects/crossfade.py`](diffhunk://#diff-78f88cc82ea2be32b9859895850edcb50d2c5522bc73e5a23eb6e1c147c067e1R1-R40): Added `CrossFadeInEffect` and `CrossFadeOutEffect` classes for fade-in and fade-out effects.

### Effect Factory Updates:
* [`src/mosaico/effects/factory.py`](diffhunk://#diff-2f4319f7a3608ae605a7cb932ff7ca0239b28972283979bedf55e1933d443569R3): Imported the new crossfade effects and updated the `EFFECT_MAP` to include `"crossfade_in"` and `"crossfade_out"`. [[1]](diffhunk://#diff-2f4319f7a3608ae605a7cb932ff7ca0239b28972283979bedf55e1933d443569R3) [[2]](diffhunk://#diff-2f4319f7a3608ae605a7cb932ff7ca0239b28972283979bedf55e1933d443569R19-R20)

### Type Definitions:
* [`src/mosaico/effects/types.py`](diffhunk://#diff-ec9d91484207a40f945aa04dfdc7c7c8b1b02be2018844f28e158af1f64545f9R3): Added the new crossfade effects to the `VideoEffect` type and updated `VideoEffectType` to include `"crossfade_in"` and `"crossfade_out"`. [[1]](diffhunk://#diff-ec9d91484207a40f945aa04dfdc7c7c8b1b02be2018844f28e158af1f64545f9R3) [[2]](diffhunk://#diff-ec9d91484207a40f945aa04dfdc7c7c8b1b02be2018844f28e158af1f64545f9R18-R34)

### Tests:
* [`tests/effects/test_factory.py`](diffhunk://#diff-dfdacd4b98eec5f16f7903b1d3bb33fdc6ab7967f43d07a11eabef8b1b55016bR3-R5): Imported the new crossfade effects and added test cases for `"crossfade_in"` and `"crossfade_out"` to ensure they are correctly created by the factory. [[1]](diffhunk://#diff-dfdacd4b98eec5f16f7903b1d3bb33fdc6ab7967f43d07a11eabef8b1b55016bR3-R5) [[2]](diffhunk://#diff-dfdacd4b98eec5f16f7903b1d3bb33fdc6ab7967f43d07a11eabef8b1b55016bR19-R22)

Closes #64 