### PR TITLE
feat: add with_config method to VideoProject class

### DIFF
--- a/src/mosaico/video/project.py
+++ b/src/mosaico/video/project.py
@@ -470,6 +470,18 @@ class VideoProject(BaseModel):
 
         return self
 
+    def with_config(self, config: VideoProjectConfig | Mapping[str, Any]) -> VideoProject:
+        """
+        Override the video project configuration.
+
+        :param config: The configuration to set.
+        :return: The updated project.
+        """
+        if isinstance(config, Mapping):
+            config = VideoProjectConfig.model_validate(config)
+        self.config = config
+        return self
+
     def with_subtitle_params(self, params: TextAssetParams | Mapping[str, Any]) -> VideoProject:
         """
         Override the subtitle parameters for the assets in the project.

--- a/tests/video/test_project.py
+++ b/tests/video/test_project.py
@@ -436,6 +436,13 @@ def test_group_words_into_phrases_with_numbers():
     assert " ".join(word.text for word in phrases[1]) == "and 6,789"
 
 
+@pytest.mark.parametrize("config", [VideoProjectConfig(title="Test"), {"title": "Test"}], ids=["object", "dict"])
+def test_with_config(config) -> None:
+    project = VideoProject().with_config(config)
+
+    assert project.config.title == "Test"
+
+
 def test_with_subtitle_params_asset_reference() -> None:
     # Create a subtitle asset
     subtitle_asset = SubtitleAsset.from_data("test text", id="subtitle1")


### PR DESCRIPTION
This pull request includes an enhancement to the `VideoProject` class and adds a new test to ensure the functionality is working correctly. The most important changes are the addition of the `with_config` method and the corresponding test case.

Enhancements to `VideoProject` class:

* [`src/mosaico/video/project.py`](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82R473-R484): Added the `with_config` method to `VideoProject` to allow overriding the video project configuration.

New test cases:

* [`tests/video/test_project.py`](diffhunk://#diff-0eb7d4bff1a2d0e58ab931e7736fecd118ae6140cdb71216a60594b091eda8cdR439-R445): Added a new test case `test_with_config` to verify that the `with_config` method correctly updates the project configuration.

Closes #69 