### PR TITLE
fix: correct storage_options default factory to use copy

### DIFF
--- a/src/mosaico/media.py
+++ b/src/mosaico/media.py
@@ -42,7 +42,7 @@ class Media(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     """The metadata of the media."""
 
-    storage_options: dict[str, Any] = Field(default_factory=lambda: settings.storage_options)
+    storage_options: dict[str, Any] = Field(default_factory=settings.storage_options.copy)
     """Media's storage options."""
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True, extra="forbid")


### PR DESCRIPTION
This pull request includes a small change to the `Media` class in the `src/mosaico/media.py` file. The change modifies the `storage_options` field to use a copy of the default storage options instead of directly referencing the settings.

* [`src/mosaico/media.py`](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL45-R45): Changed the `storage_options` field to use `settings.storage_options.copy` as the default factory to ensure a copy of the storage options is used.