### PR TITLE
fix(speech_synthesizers): fix compatibility issues with new info field

### DIFF
--- a/src/mosaico/audio_transcribers/assemblyai.py
+++ b/src/mosaico/audio_transcribers/assemblyai.py
@@ -69,7 +69,7 @@ class AssemblyAIAudioTranscriber(BaseModel):
         transcriber = aai.Transcriber(client=self._client, config=config)
 
         with audio_asset.to_bytes_io() as audio_file:
-            response = transcriber.transcribe(audio_file)
+            response = transcriber.transcribe(audio_file)  # type: ignore
 
         transcription = response.wait_for_completion()
 

--- a/src/mosaico/speech_synthesizers/elevenlabs.py
+++ b/src/mosaico/speech_synthesizers/elevenlabs.py
@@ -9,7 +9,7 @@ from pydantic.fields import Field
 from pydantic_extra_types.language_code import LanguageAlpha2
 from pydub import AudioSegment
 
-from mosaico.assets.audio import AudioAsset, AudioAssetParams
+from mosaico.assets.audio import AudioAsset, AudioAssetParams, AudioInfo
 
 
 class ElevenLabsSpeechSynthesizer(BaseModel):
@@ -84,10 +84,12 @@ class ElevenLabsSpeechSynthesizer(BaseModel):
                 response.content,
                 params=audio_params if audio_params is not None else {},
                 mime_type="audio/mpeg",
-                duration=duration,
-                sample_rate=44100,
-                sample_width=128,
-                channels=1,
+                info=AudioInfo(
+                    duration=duration,
+                    sample_rate=44100,
+                    sample_width=128,
+                    channels=1,
+                ),
             )
             assets.append(asset)
 

--- a/src/mosaico/speech_synthesizers/openai.py
+++ b/src/mosaico/speech_synthesizers/openai.py
@@ -9,7 +9,7 @@ from pydantic.types import PositiveInt
 from pydub import AudioSegment
 from typing_extensions import Self
 
-from mosaico.assets.audio import AudioAsset, AudioAssetParams
+from mosaico.assets.audio import AudioAsset, AudioAssetParams, AudioInfo
 
 
 class OpenAISpeechSynthesizer(BaseModel):
@@ -73,11 +73,13 @@ class OpenAISpeechSynthesizer(BaseModel):
                 AudioAsset.from_data(
                     response.content,
                     params=audio_params if audio_params is not None else {},
-                    duration=segment.duration,
-                    sample_rate=segment.frame_rate,
-                    sample_width=segment.sample_width,
-                    channels=segment.channels,
                     mime_type="audio/mpeg",
+                    info=AudioInfo(
+                        duration=segment.duration,
+                        sample_rate=segment.frame_rate,
+                        sample_width=segment.sample_width,
+                        channels=segment.channels,
+                    ),
                 )
             )
 


### PR DESCRIPTION
This pull request includes updates to the audio transcription and speech synthesis modules to improve type annotations and include additional audio information. The most important changes are summarized below:

### Type Annotations:

* [`src/mosaico/audio_transcribers/assemblyai.py`](diffhunk://#diff-ca73002ffc3d2f584f29884c84f1d537f5109e9707d3ea1cf49c186517cb58fdL72-R72): Added a type ignore comment to the `transcribe` method call to suppress type-checking warnings.

### Audio Information Enhancements:

* [`src/mosaico/speech_synthesizers/elevenlabs.py`](diffhunk://#diff-5ceaf5a89eebf89895b9c0fb09b280dce01d4b68467be0b852db868f4c96d18aL12-R12): Imported `AudioInfo` and updated the `synthesize` method to include audio information such as duration, sample rate, sample width, and channels in the `AudioAsset` creation. [[1]](diffhunk://#diff-5ceaf5a89eebf89895b9c0fb09b280dce01d4b68467be0b852db868f4c96d18aL12-R12) [[2]](diffhunk://#diff-5ceaf5a89eebf89895b9c0fb09b280dce01d4b68467be0b852db868f4c96d18aR87-R92)
* [`src/mosaico/speech_synthesizers/openai.py`](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51L12-R12): Imported `AudioInfo` and modified the `synthesize` method to include audio information in the `AudioAsset` creation. [[1]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51L12-R12) [[2]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51R76-R82)

Closes #72 