### PR TITLE
fix: set default temperature to 0 for GenAI aligner and fix aligner params

### DIFF
--- a/src/mosaico/transcription_aligners/genai.py
+++ b/src/mosaico/transcription_aligners/genai.py
@@ -31,7 +31,7 @@ class GenAITranscriptionAligner(TranscriptionAligner):
         :param original_text: Original script text.
         :return: A new transcription with aligned text and timing.
         """
-        model_params = self.model_params or {}
+        model_params = self.model_params or {"temperature": 0}
         fixed_transcription = self.client.chat.completions.create(
             model=self.model,
             messages=[

--- a/src/mosaico/video/project.py
+++ b/src/mosaico/video/project.py
@@ -475,6 +475,7 @@ class VideoProject(BaseModel):
                 self.add_captions(
                     audio_transcription,
                     max_duration=max_duration,
+                    aligner=aligner,
                     params=params,
                     scene_index=i,
                     overwrite=overwrite,


### PR DESCRIPTION
This pull request includes changes to improve text alignment and caption addition functionalities in the transcription and video project modules. The most important changes are:

Improvements to transcription alignment:

* [`src/mosaico/transcription_aligners/genai.py`](diffhunk://#diff-b131accc49b224fa7e21a69f04e011a7d92e19a1e3e2d00a9748bf3a91738f4eL34-R34): Updated the `align` method to include a default `temperature` parameter in `model_params` if it is not provided.

Enhancements to video project captioning:

* [`src/mosaico/video/project.py`](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82R478): Modified the `add_captions_from_transcriber` method to include an `aligner` parameter for better caption alignment.