### PR TITLE
feat: add logging and log level support with tests

### DIFF
--- a/src/mosaico/config.py
+++ b/src/mosaico/config.py
@@ -3,16 +3,21 @@ from typing import Any
 from pydantic.fields import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from mosaico.types import LogLevel
+
 
 class Settings(BaseSettings):
     """
     Settings for the Mosaico framework.
     """
 
+    log_level: LogLevel = "INFO"
+    """Log level for the application."""
+
     storage_options: dict[str, Any] = Field(default_factory=dict)
     """Default storage options for easy sharing between media/assets."""
 
-    model_config = SettingsConfigDict(env_file="mosaico_", env_nested_delimiter="__")
+    model_config = SettingsConfigDict(env_prefix="MOSAICO_", env_nested_delimiter="__", validate_assignment=True)
 
 
 settings = Settings()

--- a/src/mosaico/logging.py
+++ b/src/mosaico/logging.py
@@ -1,0 +1,54 @@
+import logging
+
+from mosaico.config import settings
+from mosaico.types import LogLevel
+
+
+LOG_FORMAT = "%(asctime)s [%(levelname)8s] %(name)s %(message)s"
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Get a logger with the given name.
+
+    This will return a logger configured according to the Mosaico log settings.
+    If a logger with the given name already exists, it will be returned.
+
+    :param name: The name of the logger.
+    :return: A logger instance.
+    """
+    logger = logging.getLogger(name)
+
+    # Only configure if the logger doesn't have handlers already
+    if not logger.handlers:
+        # Set the log level
+        level = _get_log_level(settings.log_level)
+        logger.setLevel(level)
+
+        # Set the formatter and handler
+        formatter = logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        handler.setLevel(level)
+
+        # Add the handler to the logger
+        logger.addHandler(handler)
+
+    return logger
+
+
+def configure_logging(level: LogLevel) -> None:
+    """
+    Configure the logging system.
+
+    :param level: The logging level to set.
+    """
+    settings.log_level = level
+
+
+def _get_log_level(level: LogLevel) -> int:
+    """
+    Get the logging level from the given string.
+    """
+    return getattr(logging, level.upper())

--- a/src/mosaico/types.py
+++ b/src/mosaico/types.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Any, Protocol, TypeVar, runtime_checkable
+from typing import Annotated, Any, Literal, Protocol, TypeVar, runtime_checkable
 
 from pydantic.fields import Field
 
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+"""A type alias for log levels."""
 
 FilePath = str | Path
 """A type alias for paths."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,60 @@
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from mosaico.logging import configure_logging, get_logger
+from mosaico.types import LogLevel
+
+
+def test_get_logger():
+    """Test that get_logger returns a properly configured logger."""
+    logger = get_logger("test_logger")
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "test_logger"
+    assert len(logger.handlers) > 0
+    assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+
+def test_configure_logging():
+    """Test that configure_logging updates the settings."""
+    configure_logging("DEBUG")
+    logger = get_logger("test_configure_logger")
+    assert logger.level == logging.DEBUG
+
+    # Reset to INFO for other tests
+    configure_logging("INFO")
+
+
+@pytest.mark.parametrize(
+    "level_name,level_value",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+    ],
+)
+def test_different_log_levels(level_name: LogLevel, level_value: int):
+    """Test using different log levels."""
+    configure_logging(level_name)
+    logger = get_logger(f"test_level_{level_name}")
+    assert logger.level == level_value
+
+
+def test_invalid_log_level():
+    """Test that an invalid log level raises a ValueError."""
+    with pytest.raises(ValidationError, match="INVALID"):
+        configure_logging(level="INVALID")
+
+
+def test_no_duplicate_handlers():
+    """Test that getting the same logger twice doesn't add duplicate handlers."""
+    logger1 = get_logger("test_duplicate")
+    initial_handler_count = len(logger1.handlers)
+
+    # Get the same logger again
+    logger2 = get_logger("test_duplicate")
+    assert logger1 is logger2  # Same object
+    assert len(logger2.handlers) == initial_handler_count  # No new handlers


### PR DESCRIPTION
This pull request introduces a logging system to the Mosaico framework, including configuration options and tests for various logging levels. The key changes are as follows:

### Logging System Implementation:

* [`src/mosaico/config.py`](diffhunk://#diff-40f9bfe6d5afb30644b5941f1320820d255bdbb1b67862e210073765262a9486R6-R20): Introduced a new `log_level` setting to configure the log level for the application. Updated the `model_config` to include `validate_assignment=True` for dynamic configuration changes.
* [`src/mosaico/logging.py`](diffhunk://#diff-784b48ffd515b0aa8237cb78f0afc8215e386db5329eadcb933fd01552b354c5R1-R54): Added a logging module with functions to get and configure loggers (`get_logger` and `configure_logging`). Defined log format and date format for consistent log output.
* [`src/mosaico/types.py`](diffhunk://#diff-bcc9f34f89ee8450442740a0e7ed626deeca324d02ece1a231f367c71368ea95L4-R11): Defined a `LogLevel` type alias using `Literal` for specifying valid log level strings.

### Testing:

* [`tests/test_logging.py`](diffhunk://#diff-7f5b6b29dd89cb78db1eb94863a0d6f023c3b4f28d7eb3b9b35eab84eec13381R1-R60): Added tests for the logging system to verify logger configuration, different log levels, invalid log levels, and to ensure no duplicate handlers are added when retrieving the same logger multiple times.

Closes #80 