### PR TITLE
feat: add voice speed parameter to ElevenLabsSpeechSynthesizer

### DIFF
--- a/src/mosaico/speech_synthesizers/elevenlabs.py
+++ b/src/mosaico/speech_synthesizers/elevenlabs.py
@@ -36,6 +36,9 @@ class ElevenLabsSpeechSynthesizer(BaseModel):
     voice_speaker_boost: bool = True
     """Voice speaker boost for the synthesized speech. Default is True."""
 
+    voice_speed: Annotated[float, Field(ge=0.7, le=1.2)] = 1
+    """The generated speech speed."""
+
     language_code: LanguageAlpha2 = Field(default_factory=lambda: LanguageAlpha2("en"))
     """Language code of the text to synthesize. If not provided, it defaults to "en".
 
@@ -118,6 +121,7 @@ class ElevenLabsSpeechSynthesizer(BaseModel):
                     "similarity_boost": self.voice_similarity_boost,
                     "style": self.voice_style,
                     "use_speaker_boost": self.voice_speaker_boost,
+                    "speed": self.voice_speed,
                 },
             },
             headers={"xi-api-key": self.api_key or os.getenv("ELEVENLABS_API_KEY", "")},


### PR DESCRIPTION
This pull request introduces a new feature to the `ElevenLabsSpeechSynthesizer` class, allowing users to control the speed of the synthesized speech. The most important changes include the addition of a new attribute for speech speed and its integration into the speech synthesis request.

Enhancements to speech synthesis:

* [`src/mosaico/speech_synthesizers/elevenlabs.py`](diffhunk://#diff-5ceaf5a89eebf89895b9c0fb09b280dce01d4b68467be0b852db868f4c96d18aR39-R41): Added a new attribute `voice_speed` with a range of 0.7 to 1.2 to control the speed of the generated speech.
* [`src/mosaico/speech_synthesizers/elevenlabs.py`](diffhunk://#diff-5ceaf5a89eebf89895b9c0fb09b280dce01d4b68467be0b852db868f4c96d18aR124): Updated the `_fetch_speech_synthesis` method to include the `voice_speed` parameter in the request payload.

Closes #87 