### PR TITLE
fix: news script generator now add effects to all images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ ignore = [
 "src/mosaico/**/prompts.py" = ["E501"]
 "src/mosaico/transcription_aligners/genai.py" = ["E501"]
 "cookbook/*.py" = ["F821"]
-"tests/*.py" = ["S101", "D", "ARG001", "PLR2004"]
+"tests/*.py" = ["S101", "D", "E501", "ARG001", "PLR2004"]
 "e2e/*.py" = ["S101", "D", "ARG001", "PLR2004"]
 
 [tool.ruff.lint.pylint]

--- a/src/mosaico/script_generators/news/generator.py
+++ b/src/mosaico/script_generators/news/generator.py
@@ -1,6 +1,6 @@
+import random
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, get_args
-import random
 
 from pydantic import BaseModel
 from pydantic.fields import Field

--- a/src/mosaico/script_generators/news/generator.py
+++ b/src/mosaico/script_generators/news/generator.py
@@ -1,10 +1,12 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args
+import random
 
 from pydantic import BaseModel
 from pydantic.fields import Field
 from pydantic_extra_types.language_code import LanguageAlpha2
 
+from mosaico.effects.types import VideoEffectType
 from mosaico.media import Media
 from mosaico.script_generators.news.prompts import (
     MEDIA_SUGGESTING_PROMPT,
@@ -75,6 +77,13 @@ class NewsVideoScriptGenerator:
         paragraphs = self._summarize_context(self.context, self.num_paragraphs, self.language)
         suggestions = self._suggest_paragraph_media(paragraphs, media)
         shooting_script = self._generate_shooting_script(suggestions)
+
+        for shot_index, shot in enumerate(shooting_script.shots):
+            for media_ref_index, media_ref in enumerate(shot.media_references):
+                if media_ref.type != "image" or media_ref.effects:
+                    continue
+                shooting_script.shots[shot_index].media_references[media_ref_index].effects = [_random_effect()]
+
         return shooting_script
 
     def _summarize_context(self, context: str, num_paragraphs: int, language: LanguageAlpha2) -> list[str]:
@@ -148,3 +157,10 @@ def _build_media_string(medias: Sequence[Media]) -> str:
         fmt_media = _format_media(media)
         media_str += fmt_media
     return media_str
+
+
+def _random_effect() -> VideoEffectType:
+    """
+    Suggest a random zoom or pan effect.
+    """
+    return random.choice([fx for fx in get_args(VideoEffectType) if fx.startswith(("zoom_", "pan_"))])

--- a/src/mosaico/video/project.py
+++ b/src/mosaico/video/project.py
@@ -501,7 +501,6 @@ class VideoProject(BaseModel):
         :return: The updated project.
         """
         for i, event in enumerate(self.timeline):
-            print(f"Processing event {i + 1}/{len(self.timeline)}")
             if not isinstance(event, Scene) or not event.has_audio:
                 continue
 

--- a/tests/script_generators/news/test_generator.py
+++ b/tests/script_generators/news/test_generator.py
@@ -1,0 +1,150 @@
+from unittest.mock import patch
+
+import pytest
+
+from mosaico.media import Media
+from mosaico.script_generators.news.generator import NewsVideoScriptGenerator, ParagraphMediaSuggestion, ShootingScript
+from mosaico.script_generators.script import Shot, ShotMediaReference
+
+
+@pytest.fixture
+def mock_media():
+    """Create a list of mock media objects."""
+    media1 = Media.from_data(data="test data 1", mime_type="image/jpeg", metadata={"description": "Test image 1"})
+    media1.id = "media1"
+
+    media2 = Media.from_data(data="test data 2", mime_type="image/png", metadata={"description": "Test image 2"})
+    media2.id = "media2"
+
+    media3 = Media.from_data(data="test data 3", mime_type="video/mp4", metadata={"description": "Test video"})
+    media3.id = "media3"
+
+    return [media1, media2, media3]
+
+
+@pytest.fixture
+def mock_paragraphs():
+    """Mock paragraphs returned from _summarize_context."""
+    return [
+        "First paragraph about news topic.",
+        "Second paragraph with more details.",
+        "Third paragraph with conclusion.",
+    ]
+
+
+@pytest.fixture
+def mock_suggestions():
+    """Mock suggestions returned from _suggest_paragraph_media."""
+    return [
+        ParagraphMediaSuggestion(
+            paragraph="First paragraph about news topic.", media_ids=["media1"], relevance="High relevance to the topic"
+        ),
+        ParagraphMediaSuggestion(
+            paragraph="Second paragraph with more details.",
+            media_ids=["media2", "media3"],
+            relevance="Medium relevance to the topic",
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_shooting_script():
+    """Mock shooting script returned from _generate_shooting_script."""
+    return ShootingScript(
+        title="Test News Video",
+        description="A test news video",
+        shots=[
+            Shot(
+                number=1,
+                description="Opening shot",
+                subtitle="Introduction to the topic",
+                media_references=[
+                    ShotMediaReference(media_id="media1", type="image", start_time=0.0, end_time=3.0, effects=[])
+                ],
+            ),
+            Shot(
+                number=2,
+                description="Second shot",
+                subtitle="More details",
+                media_references=[
+                    ShotMediaReference(media_id="media2", type="image", start_time=3.0, end_time=6.0, effects=[]),
+                    ShotMediaReference(
+                        media_id="media3", type="video", start_time=6.0, end_time=10.0, effects=["fade_in"]
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+@patch.object(NewsVideoScriptGenerator, "_summarize_context")
+@patch.object(NewsVideoScriptGenerator, "_suggest_paragraph_media")
+@patch.object(NewsVideoScriptGenerator, "_generate_shooting_script")
+def test_generate_adds_effects_to_images(
+    mock_generate_shooting_script,
+    mock_suggest_paragraph_media,
+    mock_summarize_context,
+    mock_media,
+    mock_paragraphs,
+    mock_suggestions,
+    mock_shooting_script,
+):
+    """Test that the generate method adds effects to images without existing effects."""
+    # Arrange
+    mock_summarize_context.return_value = mock_paragraphs
+    mock_suggest_paragraph_media.return_value = mock_suggestions
+    mock_generate_shooting_script.return_value = mock_shooting_script
+
+    generator = NewsVideoScriptGenerator(context="Test context")
+
+    # Act
+    result = generator.generate(mock_media)
+
+    # Assert
+    # Check that all image media references have effects
+    for shot in result.shots:
+        for media_ref in shot.media_references:
+            if media_ref.type == "image":
+                assert media_ref.effects, f"Media reference {media_ref.media_id} should have effects"
+                assert (
+                    len(media_ref.effects) > 0
+                ), f"Media reference {media_ref.media_id} should have at least one effect"
+                assert isinstance(media_ref.effects[0], str), "Effect should be a string"
+                # Check that the effect is one of the valid VideoEffectType values
+                assert any(
+                    media_ref.effects[0].startswith(prefix) for prefix in ["zoom_", "pan_"]
+                ), f"Effect {media_ref.effects[0]} should start with 'zoom_' or 'pan_'"
+
+
+@patch.object(NewsVideoScriptGenerator, "_summarize_context")
+@patch.object(NewsVideoScriptGenerator, "_suggest_paragraph_media")
+@patch.object(NewsVideoScriptGenerator, "_generate_shooting_script")
+@patch("mosaico.script_generators.news.generator._random_effect")
+def test_generate_uses_random_effect(
+    mock_random_effect,
+    mock_generate_shooting_script,
+    mock_suggest_paragraph_media,
+    mock_summarize_context,
+    mock_media,
+    mock_paragraphs,
+    mock_suggestions,
+    mock_shooting_script,
+):
+    """Test that the generate method uses _random_effect to add effects."""
+    # Arrange
+    mock_summarize_context.return_value = mock_paragraphs
+    mock_suggest_paragraph_media.return_value = mock_suggestions
+    mock_generate_shooting_script.return_value = mock_shooting_script
+    mock_random_effect.return_value = "zoom_in"  # Mock the random effect
+
+    generator = NewsVideoScriptGenerator(context="Test context")
+
+    # Act
+    result = generator.generate(mock_media)
+
+    # Assert
+    # Check that the random effect was used
+    assert result.shots[0].media_references[0].effects == ["zoom_in"]
+    # Check that _random_effect was called the correct number of times
+    # We expect it to be called once for each image media reference without effects
+    assert mock_random_effect.call_count == 2


### PR DESCRIPTION
This pull request includes several changes to the `mosaico` project, focusing on enhancing the script generation process for news videos, improving code quality, and adding new tests. The most important changes include adding random effects to images in shooting scripts, importing necessary modules, and expanding test coverage.

Enhancements to script generation:

* [`src/mosaico/script_generators/news/generator.py`](diffhunk://#diff-5c1f548f9b5ed085bb4cc79d46439b5244ae0ecc88e3edc43ad036d1eb0a7160R80-R86): Added logic to apply random effects to image media references without existing effects in the `generate` method.
* [`src/mosaico/script_generators/news/generator.py`](diffhunk://#diff-5c1f548f9b5ed085bb4cc79d46439b5244ae0ecc88e3edc43ad036d1eb0a7160R160-R166): Introduced the `_random_effect` function to suggest random zoom or pan effects.

Code quality improvements:

* [`src/mosaico/script_generators/news/generator.py`](diffhunk://#diff-5c1f548f9b5ed085bb4cc79d46439b5244ae0ecc88e3edc43ad036d1eb0a7160R1-R9): Added missing import for the `random` module and `get_args` from `typing`.
* [`src/mosaico/video/project.py`](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82L504): Removed a debug print statement from the `add_captions_from_transcriber` method.

Expanded test coverage:

* [`tests/script_generators/news/test_generator.py`](diffhunk://#diff-939400b5c43ebbdcd78b9e59f88884d66d67fdcbb3cbc8f9c3ccc46053aba59dR1-R150): Added new tests to verify that the `generate` method adds effects to images and uses the `_random_effect` function correctly.

Linting configuration update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L138-R138): Updated linting rules for `tests/*.py` to include `E501`.