### PR TITLE
fix: add missing voices to openai tts

### DIFF
--- a/src/mosaico/speech_synthesizers/openai.py
+++ b/src/mosaico/speech_synthesizers/openai.py
@@ -12,6 +12,10 @@ from typing_extensions import Self
 from mosaico.assets.audio import AudioAsset, AudioAssetParams, AudioInfo
 
 
+OpenAITTSVoice = Literal["alloy", "ash", "ballad", "echo", "coral", "fable", "onyx", "nova", "sage", "shimmer", "verse"]
+"""OpenAI's text-to-speech available voices."""
+
+
 class OpenAISpeechSynthesizer(BaseModel):
     """Speech synthesizer using OpenAI's API."""
 
@@ -27,7 +31,7 @@ class OpenAISpeechSynthesizer(BaseModel):
     model: Literal["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] = "gpt-4o-mini-tts"
     """Model to use for speech synthesis."""
 
-    voice: Literal["alloy", "ash", "echo", "coral", "fable", "onyx", "nova", "sage", "shimmer"] = "alloy"
+    voice: OpenAITTSVoice = "alloy"
     """Voice to use for speech synthesis."""
 
     speed: Annotated[float, Field(ge=0.25, le=4)] = 1.0


### PR DESCRIPTION
This pull request includes changes to the `src/mosaico/speech_synthesizers/openai.py` file to improve the handling of voice options for OpenAI's text-to-speech functionality. The main changes involve the introduction of a new type alias for available voices and updating the `voice` attribute in the `OpenAISpeechSynthesizer` class to use this new type alias.

Key changes:

* [`src/mosaico/speech_synthesizers/openai.py`](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51R15-R18): Added a new type alias `OpenAITTSVoice` to define the available voices for OpenAI's text-to-speech.
* [`src/mosaico/speech_synthesizers/openai.py`](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51L30-R34): Updated the `voice` attribute in the `OpenAISpeechSynthesizer` class to use the new `OpenAITTSVoice` type alias.