### PR TITLE
feat: add `strip_silence` to audio assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU General Public License (GPL)",
     "Operating System :: OS Independent",
     "Topic :: Multimedia",


### PR DESCRIPTION
This pull request introduces several enhancements to the audio processing capabilities of the `mosaico` library, including the addition of new methods for handling audio segments and stripping silence, as well as updates to the speech synthesizer to utilize these new features. Additionally, new tests have been added to ensure the correctness of these functionalities.

### Enhancements to audio processing:

* [`src/mosaico/assets/audio.py`](diffhunk://#diff-f124ef6284cb6591f111faf8fc8e7761762daf77ec190294eae23313408a0a82R91-R142): Added `to_audio_segment` method to cast audio assets to `pydub.AudioSegment` objects, and `strip_silence` method to remove leading and trailing silence from audio assets.
* [`src/mosaico/speech_synthesizers/openai.py`](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51R46-R51): Introduced `silence_threshold` and `silence_duration` parameters to the `OpenAISpeechSynthesizer` class and updated the `synthesize` method to strip silence from generated audio assets if these parameters are provided. [[1]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51R46-R51) [[2]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51R91-R92) [[3]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51L100-R108) [[4]](diffhunk://#diff-ea411bc3461fe00ddfaa9c723a016c1763cd608e2095970bcecac79ae6c0ed51L112-R123)

### Testing improvements:

* [`tests/assets/test_audio.py`](diffhunk://#diff-fc51998be71bb11cf42d47290d0422a32c1965603f554d06ec17007ae62e8bcbR2-R3): Added tests for the new `to_audio_segment` and `strip_silence` methods to validate their functionality. [[1]](diffhunk://#diff-fc51998be71bb11cf42d47290d0422a32c1965603f554d06ec17007ae62e8bcbR2-R3) [[2]](diffhunk://#diff-fc51998be71bb11cf42d47290d0422a32c1965603f554d06ec17007ae62e8bcbL126-R178)

### Minor updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R16): Added support for Python 3.13.
* [`src/mosaico/assets/audio.py`](diffhunk://#diff-f124ef6284cb6591f111faf8fc8e7761762daf77ec190294eae23313408a0a82L4-R10): Imported `cast` from `typing` and `detect_leading_silence` from `pydub.silence`.

Closes #94 