### PR TITLE
feat: add metadata field to the project root

### DIFF
--- a/src/mosaico/video/project.py
+++ b/src/mosaico/video/project.py
@@ -66,6 +66,9 @@ class VideoProject(BaseModel):
     timeline: Timeline = Field(default_factory=Timeline)
     """The timeline of assets and scenes of the video."""
 
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """The metadata of the video project."""
+
     model_config = ConfigDict(validate_assignment=True)
 
     @property


### PR DESCRIPTION
This pull request introduces a new `metadata` field to the `VideoProject` class in `src/mosaico/video/project.py`. This field allows storing additional metadata about the video project.

* [`src/mosaico/video/project.py`](diffhunk://#diff-479c327a9afd7c0cbcd76cfd4d3811f62f0e849a6ff1304fbf632dca3b915a82R69-R71): Added a `metadata` field of type `dict[str, Any]` with a default empty dictionary to the `VideoProject` class. This field provides a flexible way to store metadata for video projects.

Closes #99 