### PR TITLE
feat: add Base64 encoding/decoding for media data

### DIFF
--- a/src/mosaico/transcription_aligners/sequence_matcher.py
+++ b/src/mosaico/transcription_aligners/sequence_matcher.py
@@ -47,7 +47,7 @@ class SequenceMatcherTranscriptionAligner(TranscriptionAligner):
                 # No change needed, keep original words and time ranges
                 logger.debug("No change needed, keeping original words and time ranges.")
                 for word in words_with_time_ranges[i1:i2]:
-                    fixed_words.append(word.copy())
+                    fixed_words.append(word.model_copy())
 
             elif tag == "replace":
                 # Replace words but adapt their time ranges


### PR DESCRIPTION
This pull request introduces enhancements to the `Media` class in `src/mosaico/media.py` to support Base64 encoding and decoding for the `data` field, along with corresponding updates to the test suite. It also includes a minor refactor in `src/mosaico/transcription_aligners/sequence_matcher.py` for improved method usage. Below are the most important changes:

### Enhancements to `Media` class for Base64 handling:
* Added `_BASE64_BYTE_PATTERN` regex to identify Base64-encoded strings and implemented a `@field_validator` method (`decode_base64_data`) to decode Base64 strings into bytes during validation. [[1]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL14-R28) [[2]](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbR82-R109)
* Introduced a `@field_serializer` method (`encode_base64_data`) to encode bytes into Base64 strings when serializing the `data` field to JSON.

### Updates to the test suite:
* Added multiple test cases in `tests/test_media.py` to validate the new Base64 encoding/decoding functionality, including scenarios for valid Base64 strings, non-Base64 strings, non-ASCII strings, and edge cases like empty strings. [[1]](diffhunk://#diff-14470160d981b140eb73b28994138ed344e5649e271cf511a6f420142e2acf9eR1-R2) [[2]](diffhunk://#diff-14470160d981b140eb73b28994138ed344e5649e271cf511a6f420142e2acf9eR32-R94)

### Refactor in transcription aligner:
* Replaced the use of `copy()` with `model_copy()` for `word` objects in the `align` method of `src/mosaico/transcription_aligners/sequence_matcher.py` to align with updated method naming conventions.