### PR TITLE
chore: correct property name from `credit` to `credits` in Media class

### DIFF
--- a/src/mosaico/media.py
+++ b/src/mosaico/media.py
@@ -55,11 +55,11 @@ class Media(BaseModel):
         return self.metadata.get("description", "")
 
     @property
-    def credit(self) -> str:
+    def credits(self) -> str:
         """
         Returns the credits of the media.
         """
-        return self.metadata.get("credit", "")
+        return self.metadata.get("credits", "")
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -252,3 +252,17 @@ def test_media_roundtrip_conversion():
     assert original_media.data == converted_media.data
     assert original_media.mime_type == converted_media.mime_type
     assert original_media.metadata == converted_media.metadata
+
+
+def test_metadata_properties_extraction():
+    """Test extraction of credits metadata"""
+    media = Media(
+        id="test-id",
+        data="test data",
+        mime_type="text/plain",
+        metadata={"description": "Test description", "credits": ["Credit 1", "Credit 2"]},
+    )
+    media_credits = media.credits
+    description = media.description
+    assert description == "Test description"
+    assert media_credits == ["Credit 1", "Credit 2"]


### PR DESCRIPTION
This pull request includes a minor update to the `src/mosaico/media.py` file, renaming a method and updating its implementation to align with a metadata key change.

* Renamed the `credit` method to `credits` and updated the metadata key it retrieves from `"credit"` to `"credits"`. This ensures consistency with the updated metadata structure.
This pull request updates the `Media` class to rename and enhance the metadata handling for credits and adds a new test to verify the changes. The most important changes include renaming the `credit` property to `credits` and introducing a test for metadata property extraction.

### Updates to the `Media` class:

* [`src/mosaico/media.py`](diffhunk://#diff-af21c61b7b7fcf311979e890162dc80f125f7deaebbe053970345a857b91e9cbL58-R62): Renamed the `credit` property to `credits` to better reflect the plural nature of the data being returned. Updated the metadata key accessed from `"credit"` to `"credits"`.

### Additions to the test suite:

* [`tests/test_media.py`](diffhunk://#diff-14470160d981b140eb73b28994138ed344e5649e271cf511a6f420142e2acf9eR255-R268): Added a new test, `test_metadata_properties_extraction`, to verify the correct extraction of `description` and `credits` metadata from a `Media` object.