### PR TITLE
fix: ensure min dims for text size and expand shadow image size to fit offsets

### DIFF
--- a/src/mosaico/clip_makers/text.py
+++ b/src/mosaico/clip_makers/text.py
@@ -4,9 +4,9 @@ import math
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import cast
 
+import numpy as np
 from find_system_fonts_filename import get_system_fonts_filename
 from moviepy.Clip import Clip
 from moviepy.video.VideoClip import ImageClip
@@ -144,15 +144,13 @@ class TextClipMaker(BaseClipMaker[BaseTextAsset]):
 
         bbox = final_image.getbbox()
         final_image = final_image.crop(bbox)
+        np_image = np.asarray(final_image)
 
-        with NamedTemporaryFile(suffix=".png") as f:
-            final_image.save(f.name, "PNG")
-
-            return (
-                ImageClip(f.name)
-                .with_position((params.position.x, params.position.y), relative=is_relative_position(params.position))
-                .with_duration(self.duration)
-            )
+        return (
+            ImageClip(np_image)
+            .with_position((params.position.x, params.position.y), relative=is_relative_position(params.position))
+            .with_duration(self.duration)
+        )
 
 
 @dataclass

--- a/tests/clip_makers/test_text.py
+++ b/tests/clip_makers/test_text.py
@@ -1,7 +1,13 @@
+import math
+
 from PIL import ImageFont
 
+from mosaico.assets.factory import create_asset
+from mosaico.assets.text import TextAssetParams
+from mosaico.clip_makers.factory import make_clip
 from mosaico.clip_makers.text import (
     SystemFont,
+    _draw_text_shadow_image,
     _get_font_text_size,
     _get_system_fallback_font_name,
     _list_system_fonts,
@@ -9,6 +15,8 @@ from mosaico.clip_makers.text import (
     _slugify_font_name,
     _wrap_text,
 )
+from mosaico.positioning.region import RegionPosition
+from mosaico.positioning.relative import RelativePosition
 
 
 def test_system_font_properties():
@@ -91,3 +99,111 @@ def test_font_matching():
     assert font.matches("DejaVuSans-Bold")
     assert font.matches("dejavusans-bold")
     assert not font.matches("Arial")
+
+
+def test_shadow_image_size_expansion():
+    """Test that shadow image size is expanded to accommodate shadow offset."""
+    font = _load_font(_get_system_fallback_font_name(), 40)
+    text = "Test text"
+    text_size = (50, 30)
+
+    # Create shadow image with large offset
+    shadow_image = _draw_text_shadow_image(
+        text=text,
+        text_size=text_size,
+        font=font,
+        line_height=0,
+        align="left",
+        shadow_color="black",
+        shadow_angle=0,
+        shadow_distance=40,  # Large offset
+        shadow_blur=2,
+        shadow_opacity=0.8,
+    )
+
+    # Shadow image should be expanded to accommodate the offset
+    # With 40 pixel offset at 0 degrees, width should be 50 + 40 = 90
+    assert shadow_image.size[0] == text_size[0] + 40  # 90
+    assert shadow_image.size[1] == text_size[1]  # 30
+
+    # Test with different angle
+    shadow_image_diagonal = _draw_text_shadow_image(
+        text=text,
+        text_size=text_size,
+        font=font,
+        line_height=0,
+        align="left",
+        shadow_color="black",
+        shadow_angle=45,  # 45 degree angle
+        shadow_distance=30,
+        shadow_blur=0,
+        shadow_opacity=1.0,
+    )
+
+    # With 45 degree angle, both x and y offsets should be ~21 pixels
+    # So both width and height should be expanded
+    expected_offset = abs(round(30 * math.cos(math.radians(45))))
+    assert shadow_image_diagonal.size[0] == text_size[0] + expected_offset
+    assert shadow_image_diagonal.size[1] == text_size[1] + expected_offset
+
+
+def test_user_scenario_with_negative_shadow_offset():
+    """Test the exact scenario that caused the user's SystemError with negative shadow offset."""
+
+    # Exact parameters from user's failing scenario
+    text = "Los Angeles está sob toque de recolher enquanto protestos contra operações anti-imigração do presidente Trump se espalham por várias cidades americanas, com confrontos entre manifestantes e policiais."
+
+    params = TextAssetParams(
+        position=RegionPosition(x="center", y="bottom"),
+        font_size=45,
+        font_color="#fff",
+        font_kerning=0,
+        line_height=10,
+        stroke_color="#000",
+        stroke_width=1,
+        shadow_color="#000",
+        shadow_blur=10,
+        shadow_opacity=0.5,
+        shadow_angle=135,  # This creates negative x_offset
+        shadow_distance=5,
+        background_color="#0000",
+        align="center",
+        z_index=0,
+    )
+
+    # Create asset and make clip - this should work without SystemError
+    asset = create_asset("text", data=text, params=params)
+    resolution = (1920, 1080)
+    duration = 16
+
+    # This should not raise SystemError: tile cannot extend outside image
+    clip = make_clip(asset, duration, resolution, effects=[])
+
+    # Verify the clip was created successfully
+    assert clip is not None
+    assert clip.size[0] > 0
+    assert clip.size[1] > 0
+
+
+def test_empty_text_handling():
+    """Test that empty text doesn't cause SystemError: tile cannot extend outside image."""
+
+    # Create an empty text asset (this was causing the SystemError)
+    params = TextAssetParams(
+        position=RelativePosition(x=0.1, y=0.325),
+        font_size=54,
+        line_height=2,  # This was the specific combination causing issues
+    )
+
+    # Create asset with empty text
+    asset = create_asset("text", data="", params=params)
+
+    # This should not raise SystemError: tile cannot extend outside image
+    resolution = (1920, 1080)
+    duration = 5
+    clip = make_clip(asset, duration, resolution, effects=[])
+
+    # Verify the clip was created successfully with minimum dimensions
+    assert clip is not None
+    assert clip.size[0] >= 1  # Should have minimum width
+    assert clip.size[1] >= 1  # Should have minimum height


### PR DESCRIPTION
This pull request addresses several issues in the `text.py` clip-making functionality, focusing on improving robustness against edge cases and preventing errors related to image dimensions. It also includes new test cases to validate these fixes and ensure proper handling of problematic scenarios.

### Fixes for text rendering issues:
* [`src/mosaico/clip_makers/text.py`](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R104-R106): Added a safeguard to ensure text dimensions have a minimum size of 1x1 pixels, preventing errors with zero-sized images.
* [`src/mosaico/clip_makers/text.py`](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46R137-R140): Updated logic to handle mismatched shadow and text image sizes by creating a composite image, ensuring consistent rendering.

### Improvements to shadow image generation:
* [`src/mosaico/clip_makers/text.py`](diffhunk://#diff-c86f710a397bedfc973662148345b1f251c04d97cb1e81fe949f88a4e221db46L323-R333): Expanded shadow image dimensions to accommodate offsets caused by shadow distance and angle, preventing clipping issues.

### New test cases for edge scenarios:
* [`tests/clip_makers/test_text.py`](diffhunk://#diff-12331c9b81fb71f5b6e19f8106e86560e5ccdfefd69cef1cf22badea465c3a05R102-R209): Added `test_shadow_image_size_expansion` to validate shadow image resizing logic for large offsets and diagonal angles.
* [`tests/clip_makers/test_text.py`](diffhunk://#diff-12331c9b81fb71f5b6e19f8106e86560e5ccdfefd69cef1cf22badea465c3a05R1-R19): Added `test_user_scenario_with_negative_shadow_offset` and `test_empty_text_handling` to reproduce and resolve user-reported errors, ensuring proper handling of negative offsets and empty text assets.

Closes #109 